### PR TITLE
Make pandas and polars support optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+pandas = ["pandas>=0.12.0"]
+polars = ["polars>=0.18"]
+
 [tool.maturin]
 features = ["pyo3/extension-module"]
 python-source = "python"
@@ -20,3 +24,9 @@ bindings = 'pyo3'
 
 [tool.pytest.ini_options]
 testpaths = "tests"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.24.0",
+]

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,7 +1,21 @@
+from __future__ import annotations
+
 from pysnaptest import snapshot, assert_json_snapshot, assert_dataframe_snapshot
-import pandas as pd
-import polars as pl
 import pytest
+
+try:
+    import pandas as pd
+
+    PANDAS_UNAVAILABLE = False
+except ImportError:
+    PANDAS_UNAVAILABLE = True
+
+try:
+    import polars as pl
+
+    POLARS_UNAVAILABLE = False
+except ImportError:
+    POLARS_UNAVAILABLE = True
 
 
 @snapshot
@@ -27,11 +41,13 @@ def test_assert_snapshot():
     assert_json_snapshot("expected_result")
 
 
+@pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="Pandas is an optional dependency")
 def test_assert_pandas_dataframe_snapshot():
     df = pd.DataFrame({"name": ["foo", "bar"], "id": [1, 2]})
     assert_dataframe_snapshot(df, index=False)
 
 
+@pytest.mark.skipif(POLARS_UNAVAILABLE, reason="Polars is an optional dependency")
 @snapshot
 def test_assert_polars_dataframe_snapshot() -> pl.DataFrame:
     return pl.DataFrame(


### PR DESCRIPTION
I've picked the oldest versions of pandas and polars I could find that have the `.to_csv()`/`.write_csv()` methods we need.