### PR TITLE
Add assert_binary_snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -124,16 +124,17 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "insta"
-version = "1.41.1"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+checksum = "71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86"
 dependencies = [
  "console",
  "csv",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "pest",
  "pest_derive",
+ "pin-project",
  "serde",
  "similar",
 ]
@@ -143,12 +144,6 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -185,9 +180,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
  "thiserror",
@@ -196,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.13"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
 dependencies = [
  "pest",
  "pest_generator",
@@ -206,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.13"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
 dependencies = [
  "pest",
  "pest_meta",
@@ -219,13 +214,33 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.13"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -236,18 +251,18 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e484fd2c8b4cb67ab05a318f1fd6fa8f199fcc30819f08f07d200809dba26c15"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -263,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e0469a84f208e20044b98965e1561028180219e35352a2afaf2b942beff3b"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -274,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -284,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb6da8ec6fa5cedd1626c886fc8749bdcbb09424a86461eb8cdf096b7c33257"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -296,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a385202ff5a92791168b1136afae5059d3ac118457bb7bc304c197c2d33e7d"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -309,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "pysnaptest"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "csv",
  "insta",
@@ -340,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -355,18 +370,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -375,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -404,15 +419,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,18 +442,18 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -459,9 +474,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysnaptest"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 include = [
     "/pyproject.toml",
@@ -24,7 +24,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 csv = "1.3.1"
-insta = { version = "1.41", features = ["json", "csv", "redactions"] }
+insta = { version = "1.42", features = ["json", "csv", "redactions"] }
 pyo3 = { version = "0.23.1", features = ["generate-import-lib"] }
 pythonize = "0.23.0"
 serde = { version = "1.0.216", features = ["derive"] }

--- a/python/pysnaptest/__init__.py
+++ b/python/pysnaptest/__init__.py
@@ -5,4 +5,5 @@ from .snapshot import (
     assert_csv_snapshot,
     assert_snapshot,
     assert_dataframe_snapshot,
+    assert_binary_snapshot
 )

--- a/python/pysnaptest/__init__.py
+++ b/python/pysnaptest/__init__.py
@@ -5,5 +5,5 @@ from .snapshot import (
     assert_csv_snapshot,
     assert_snapshot,
     assert_dataframe_snapshot,
-    assert_binary_snapshot
+    assert_binary_snapshot,
 )

--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from ._pysnaptest import assert_json_snapshot as _assert_json_snapshot
 from ._pysnaptest import assert_csv_snapshot as _assert_csv_snapshot
 from ._pysnaptest import assert_snapshot as _assert_snapshot
+from ._pysnaptest import assert_binary_snapshot as _assert_binary_snapshot
 from ._pysnaptest import TestInfo
 from typing import Callable, Any, Dict, overload, Union, Optional, TYPE_CHECKING
 from functools import partial, wraps
@@ -80,6 +81,13 @@ def assert_dataframe_snapshot(
             "(We may also be unable to import both pandas and polars for some reason, but this is not likely)"
         )
     assert_csv_snapshot(result, snapshot_path, snapshot_name, redactions)
+
+
+def assert_binary_snapshot(
+    result: bytes, snapshot_path: str | None = None, snapshot_name: str | None = None, extension: str = "bin"
+):
+    test_info = extract_from_pytest_env(snapshot_path, snapshot_name)
+    _assert_binary_snapshot(test_info, extension, result)
 
 
 def assert_snapshot(

--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -84,7 +84,10 @@ def assert_dataframe_snapshot(
 
 
 def assert_binary_snapshot(
-    result: bytes, snapshot_path: str | None = None, snapshot_name: str | None = None, extension: str = "bin"
+    result: bytes,
+    snapshot_path: str | None = None,
+    snapshot_name: str | None = None,
+    extension: str = "bin",
 ):
     test_info = extract_from_pytest_env(snapshot_path, snapshot_name)
     _assert_binary_snapshot(test_info, extension, result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,16 @@ fn assert_csv_snapshot(
 }
 
 #[pyfunction]
+fn assert_binary_snapshot(test_info: &TestInfo, extension: &str, result: Vec<u8>) -> PyResult<()> {
+    let snapshot_name = test_info.snapshot_name();
+    let settings: insta::Settings = test_info.try_into()?;
+    settings.bind(|| {
+        insta::assert_binary_snapshot!(format!("{snapshot_name}.{extension}").as_str(), result);
+    });
+    Ok(())
+}
+
+#[pyfunction]
 fn assert_snapshot(test_info: &TestInfo, result: &Bound<'_, PyAny>) -> PyResult<()> {
     let snapshot_name = test_info.snapshot_name();
     let settings: insta::Settings = test_info.try_into()?;
@@ -252,6 +262,7 @@ fn pysnaptest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TestInfo>()?;
 
     m.add_function(wrap_pyfunction!(assert_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(assert_binary_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_json_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_csv_snapshot, m)?)?;
     Ok(())

--- a/tests/snapshots/pysnaptest__test_snapshots_test_assert_binary_snapshot@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_assert_binary_snapshot@pysnap.snap
@@ -1,0 +1,6 @@
+---
+source: src/lib.rs
+description: "Test File Path: tests/test_snapshots.py"
+extension: txt
+snapshot_kind: binary
+---

--- a/tests/snapshots/pysnaptest__test_snapshots_test_assert_binary_snapshot@pysnap.snap.txt
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_assert_binary_snapshot@pysnap.snap.txt
@@ -1,0 +1,1 @@
+expected_result

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -4,7 +4,7 @@ from pysnaptest import (
     snapshot,
     assert_json_snapshot,
     assert_dataframe_snapshot,
-    assert_binary_snapshot
+    assert_binary_snapshot,
 )
 import pytest
 
@@ -44,6 +44,7 @@ def test_assert_json_snapshot():
 
 def test_assert_snapshot():
     assert_json_snapshot("expected_result")
+
 
 def test_assert_binary_snapshot():
     assert_binary_snapshot(b"expected_result", extension="txt")

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -46,7 +46,7 @@ def test_assert_snapshot():
     assert_json_snapshot("expected_result")
 
 def test_assert_binary_snapshot():
-    assert_binary_snapshot(b"expected_result")
+    assert_binary_snapshot(b"expected_result", extension="txt")
 
 
 @pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="Pandas is an optional dependency")

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -4,6 +4,7 @@ from pysnaptest import (
     snapshot,
     assert_json_snapshot,
     assert_dataframe_snapshot,
+    assert_binary_snapshot
 )
 import pytest
 
@@ -43,6 +44,9 @@ def test_assert_json_snapshot():
 
 def test_assert_snapshot():
     assert_json_snapshot("expected_result")
+
+def test_assert_binary_snapshot():
+    assert_binary_snapshot(b"expected_result")
 
 
 @pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="Pandas is an optional dependency")


### PR DESCRIPTION
This doesn't work for now, snapshots seem to change with each run of the test. There also seem to be a bug with the suffix when reviewing it (will try to reproduce in pure rust). 

This has been resolved by updating cargo-insta to latest.