### PR TITLE
Fix allow_duplicates propagation

### DIFF
--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -233,7 +233,12 @@ def insta_snapshot(
     else:
         if redactions is not None:
             raise ValueError("Redactions may only be used with json or csv snapshots.")
-        assert_snapshot(result, snapshot_path, snapshot_name)
+        assert_snapshot(
+            result,
+            snapshot_path,
+            snapshot_name,
+            allow_duplicates=allow_duplicates,
+        )
 
 
 @overload


### PR DESCRIPTION
## Summary
- propagate `allow_duplicates` flag when using `insta_snapshot` for simple values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*

------
https://chatgpt.com/codex/tasks/task_e_6883798975d48323a31c4fd9560b2e27