### PR TITLE
Fix typo in dataframe snapshot error

### DIFF
--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -104,7 +104,7 @@ def assert_pandas_dataframe_snapshot(
         )
     else:
         raise ValueError(
-            "Unsupported snqpshot format for dataframes, supported formats are: 'csv', 'json', 'parquet'."
+            "Unsupported snapshot format for dataframes, supported formats are: 'csv', 'json', 'parquet'."
         )
 
 


### PR DESCRIPTION
## Summary
- fix a typo in pandas dataframe snapshot error message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*
- `pip install .` *(fails: Could not find a version that satisfies the requirement maturin)*

------
https://chatgpt.com/codex/tasks/task_e_68837b8271888323a5e81192bacd8be3