### PR TITLE
Fix snapshot decorator overload args

### DIFF
--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -243,8 +243,8 @@ def snapshot(func: Callable) -> Callable: ...
 @overload
 def snapshot(
     *,
-    filename: Optional[str] = None,
-    folder_path: Optional[str] = None,
+    snapshot_path: Optional[str] = None,
+    snapshot_name: Optional[str] = None,
     redactions: Optional[Dict[str, str | int | None]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,


### PR DESCRIPTION
## Summary
- update overload args for `snapshot` decorator

## Testing
- `ruff format python/pysnaptest/snapshot.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*

------
https://chatgpt.com/codex/tasks/task_e_68837b085cb48323a751bbad60cf0289