### PR TITLE
Add csv snapshot test

### DIFF
--- a/tests/snapshots/pysnaptest__test_snapshots_test_assert_csv_snapshot_simple@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_assert_csv_snapshot_simple@pysnap.snap
@@ -1,0 +1,7 @@
+---
+source: src/lib.rs
+description: "Test File Path: tests/test_snapshots.py"
+---
+a,b
+1,2
+

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -6,6 +6,7 @@ import json
 from pysnaptest import (
     snapshot,
     assert_json_snapshot,
+    assert_csv_snapshot,
     assert_dataframe_snapshot,
     assert_binary_snapshot,
     sorted_redaction,
@@ -95,6 +96,10 @@ def test_assert_snapshot():
 
 def test_assert_binary_snapshot():
     assert_binary_snapshot(b"expected_result", extension="txt")
+
+
+def test_assert_csv_snapshot_simple():
+    assert_csv_snapshot("a,b\n1,2")
 
 
 @pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="Pandas is an optional dependency")


### PR DESCRIPTION
## Summary
- add assert_csv_snapshot import
- add new test for assert_csv_snapshot
- store new expected snapshot

## Testing
- `ruff format tests/test_snapshots.py`
- `pytest tests/test_snapshots.py::test_assert_csv_snapshot_simple -vv` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*
- `pip install -e .[pandas,polars,pyarrow]` *(fails: Could not find a version that satisfies the requirement maturin<2.0,>=1.7)*

------
https://chatgpt.com/codex/tasks/task_e_68837baf167c832393891522ee67532b