### PR TITLE
Fix allow_duplicates pass-through in insta_snapshot

### DIFF
--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -285,7 +285,13 @@ def insta_snapshot(
     allow_duplicates: bool = False,
 ):
     if isinstance(result, dict) or isinstance(result, list):
-        assert_json_snapshot(result, snapshot_path, snapshot_name, redactions)
+        assert_json_snapshot(
+            result,
+            snapshot_path,
+            snapshot_name,
+            redactions,
+            allow_duplicates,
+        )
     elif isinstance(result, bytes):
         assert_binary_snapshot(
             result,


### PR DESCRIPTION
## Summary
- ensure `insta_snapshot` forwards the `allow_duplicates` flag when delegating to `assert_json_snapshot`

## Testing
- `ruff format --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*
- `cargo check` *(fails: could not fetch crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688382fe73a083239c19ace9bde8161c