### PR TITLE
Remove anyhow dependency and use custom error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,7 +326,6 @@ dependencies = [
 name = "pysnaptest"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "csv",
  "insta",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ name = "pysnaptest"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.98"
 csv = "1.3.1"
 insta = { version = "1.42", features = ["json", "csv", "redactions"] }
 once_cell = "1.20.3"


### PR DESCRIPTION
## Summary
- drop `anyhow` dependency
- add `SnapshotError` error type
- update snapshot helpers and tests to use `SnapshotError`

## Testing
- `cargo test --quiet` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_688385d1ec108323a54852302f3df8d4