### PR TITLE
Refactor errors module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,7 +326,6 @@ dependencies = [
 name = "pysnaptest"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "csv",
  "insta",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ name = "pysnaptest"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.98"
 csv = "1.3.1"
 insta = { version = "1.42", features = ["json", "csv", "redactions"] }
 once_cell = "1.20.3"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::env::VarError;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::{self, FromStr};

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,6 +11,8 @@ use once_cell::sync::Lazy;
 use pyo3::FromPyObject;
 use pyo3::{exceptions::PyValueError, pyclass, pymethods, Bound, PyAny, PyErr, PyResult};
 
+use crate::errors::PytestInfoError;
+
 use insta::internals::{Redaction, SnapshotContents};
 use insta::{rounded_redaction, sorted_redaction, Snapshot};
 use pyo3::types::PyAnyMethods;
@@ -43,37 +45,14 @@ pub(crate) struct PytestInfo {
     test_name: String,
 }
 
-#[derive(Debug)]
-pub(crate) enum Error {
-    CouldNotSplit(String),
-    InvalidEnvVar(VarError),
-    NoTestFile,
-}
-
-impl From<Error> for PyErr {
-    fn from(value: Error) -> Self {
-        match value {
-            Error::CouldNotSplit(s) => PyValueError::new_err(format!(
-                "Expected '::' to be in PYTEST_CURRENT_TEST string ({s})"
-            )),
-            Error::InvalidEnvVar(ve) => match ve {
-                VarError::NotPresent => PyValueError::new_err("PYTEST_CURRENT_TEST is not set"),
-                VarError::NotUnicode(os_string) => PyValueError::new_err(format!(
-                    "PYTEST_CURRENT_TEST is not a valid unicode string: {os_string:#?}"
-                )),
-            },
-            Error::NoTestFile => PyValueError::new_err("No test file found"),
-        }
-    }
-}
 
 impl PytestInfo {
-    pub fn from_env() -> Result<Self, Error> {
-        let pytest_str = env::var("PYTEST_CURRENT_TEST").map_err(Error::InvalidEnvVar)?;
+    pub fn from_env() -> Result<Self, PytestInfoError> {
+        let pytest_str = env::var("PYTEST_CURRENT_TEST").map_err(PytestInfoError::InvalidEnvVar)?;
         pytest_str.parse()
     }
 
-    pub fn test_path(&self) -> Result<PathBuf, Error> {
+    pub fn test_path(&self) -> Result<PathBuf, PytestInfoError> {
         let path = self.test_path_raw();
         if path.exists() {
             Ok(path)
@@ -82,7 +61,7 @@ impl PytestInfo {
             filepath.push(filename);
             Ok(filepath)
         } else {
-            Err(Error::NoTestFile)
+            Err(PytestInfoError::NoTestFile)
         }
     }
 
@@ -92,12 +71,12 @@ impl PytestInfo {
 }
 
 impl FromStr for PytestInfo {
-    type Err = Error;
+    type Err = PytestInfoError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (test_path, test_name_and_stage) = s
             .split_once("::")
-            .ok_or(Error::CouldNotSplit(s.to_string()))?;
+            .ok_or(PytestInfoError::CouldNotSplit(s.to_string()))?;
 
         let test_name = test_name_and_stage
             .split_once(" ")
@@ -260,21 +239,21 @@ mod tests {
     #[test]
     fn test_into_pyinfo_happy_path() {
         let s = "tests/a/b/test_thing.py::test_a (call)";
-        let pti: Result<PytestInfo, Error> = s.parse();
+        let pti: Result<PytestInfo, PytestInfoError> = s.parse();
         insta::assert_debug_snapshot!(pti)
     }
 
     #[test]
     fn test_into_pyinfo_no_trailer() {
         let s = "tests/a/b/test_thing.py::test_a";
-        let pti: Result<PytestInfo, Error> = s.parse();
+        let pti: Result<PytestInfo, PytestInfoError> = s.parse();
         insta::assert_debug_snapshot!(pti)
     }
 
     #[test]
     fn test_into_pyinfo_failure_case() {
         let s = "tests/a/b/test_thing.py";
-        let pti: Result<PytestInfo, Error> = s.parse();
+        let pti: Result<PytestInfo, PytestInfoError> = s.parse();
         insta::assert_debug_snapshot!(pti)
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -44,7 +44,6 @@ pub(crate) struct PytestInfo {
     test_name: String,
 }
 
-
 impl PytestInfo {
     pub fn from_env() -> Result<Self, PytestInfoError> {
         let pytest_str = env::var("PYTEST_CURRENT_TEST").map_err(PytestInfoError::InvalidEnvVar)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,71 @@
+use std::env::VarError;
+use std::fmt::{self, Display, Formatter};
+
+use pyo3::PyErr;
+use pyo3::exceptions::PyValueError;
+
+#[derive(Debug)]
+pub enum PytestInfoError {
+    CouldNotSplit(String),
+    InvalidEnvVar(VarError),
+    NoTestFile,
+}
+
+impl From<PytestInfoError> for PyErr {
+    fn from(value: PytestInfoError) -> Self {
+        match value {
+            PytestInfoError::CouldNotSplit(s) => PyValueError::new_err(format!(
+                "Expected '::' to be in PYTEST_CURRENT_TEST string ({s})"
+            )),
+            PytestInfoError::InvalidEnvVar(ve) => match ve {
+                VarError::NotPresent => PyValueError::new_err("PYTEST_CURRENT_TEST is not set"),
+                VarError::NotUnicode(os_string) =>
+                    PyValueError::new_err(format!("PYTEST_CURRENT_TEST is not a valid unicode string: {os_string:#?}")),
+            },
+            PytestInfoError::NoTestFile => PyValueError::new_err("No test file found"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SnapError(pub String);
+
+impl Display for SnapError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for SnapError {}
+
+impl From<String> for SnapError {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SnapError {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<std::io::Error> for SnapError {
+    fn from(value: std::io::Error) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<serde_json::Error> for SnapError {
+    fn from(value: serde_json::Error) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<PyErr> for SnapError {
+    fn from(value: PyErr) -> Self {
+        Self(value.to_string())
+    }
+}
+
+pub type SnapResult<T> = Result<T, SnapError>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter};
 
 use pyo3::exceptions::PyValueError;
 use pyo3::PyErr;
+use pythonize::PythonizeError;
 
 #[derive(Debug)]
 pub enum PytestInfoError {
@@ -52,6 +53,8 @@ pub enum SnapError {
     Json(serde_json::Error),
     Py(PyErr),
     PytestInfo(PytestInfoError),
+    Pythonize(PythonizeError),
+    Other(Box<dyn std::error::Error>)
 }
 
 impl Display for SnapError {
@@ -62,6 +65,8 @@ impl Display for SnapError {
             SnapError::Json(e) => write!(f, "{e}"),
             SnapError::Py(e) => write!(f, "{e}"),
             SnapError::PytestInfo(e) => write!(f, "{e}"),
+            SnapError::Pythonize(e) => write!(f, "{e}"),
+            SnapError::Other(e) => write!(f, "{e}"),
         }
     }
 }
@@ -83,6 +88,18 @@ impl From<&str> for SnapError {
 impl From<std::io::Error> for SnapError {
     fn from(value: std::io::Error) -> Self {
         SnapError::Io(value)
+    }
+}
+
+impl From<PythonizeError> for SnapError {
+    fn from(value: PythonizeError) -> Self {
+        SnapError::Pythonize(value)
+    }
+}
+
+impl From<Box<dyn std::error::Error>> for SnapError {
+    fn from(err: Box<dyn std::error::Error>) -> Self {
+        SnapError::Other(err)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,7 +21,10 @@ impl Display for PytestInfoError {
             PytestInfoError::InvalidEnvVar(e) => match e {
                 VarError::NotPresent => write!(f, "PYTEST_CURRENT_TEST is not set"),
                 VarError::NotUnicode(os_string) => {
-                    write!(f, "PYTEST_CURRENT_TEST is not a valid unicode string: {os_string:#?}")
+                    write!(
+                        f,
+                        "PYTEST_CURRENT_TEST is not a valid unicode string: {os_string:#?}"
+                    )
                 }
             },
             PytestInfoError::NoTestFile => write!(f, "No test file found"),
@@ -32,9 +35,9 @@ impl Display for PytestInfoError {
 impl From<PytestInfoError> for PyErr {
     fn from(value: PytestInfoError) -> Self {
         match value {
-            PytestInfoError::CouldNotSplit(s) => {
-                PyValueError::new_err(format!("Expected '::' to be in PYTEST_CURRENT_TEST string ({s})"))
-            }
+            PytestInfoError::CouldNotSplit(s) => PyValueError::new_err(format!(
+                "Expected '::' to be in PYTEST_CURRENT_TEST string ({s})"
+            )),
             PytestInfoError::InvalidEnvVar(ve) => match ve {
                 VarError::NotPresent => PyValueError::new_err("PYTEST_CURRENT_TEST is not set"),
                 VarError::NotUnicode(os_string) => PyValueError::new_err(format!(
@@ -54,7 +57,7 @@ pub enum SnapError {
     Py(PyErr),
     PytestInfo(PytestInfoError),
     Pythonize(PythonizeError),
-    Other(Box<dyn std::error::Error>)
+    Other(Box<dyn std::error::Error>),
 }
 
 impl Display for SnapError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,11 @@ use pyo3::{
 
 mod common;
 mod mocks;
+mod errors;
 
 pub use common::*;
 pub use mocks::*;
+pub use errors::*;
 
 use std::{collections::HashMap, path::PathBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,12 @@ use pyo3::{
 };
 
 mod common;
-mod mocks;
 mod errors;
+mod mocks;
 
 pub use common::*;
-pub use mocks::*;
 pub use errors::*;
+pub use mocks::*;
 
 use std::{collections::HashMap, path::PathBuf};
 

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -159,11 +159,11 @@ fn wrap_py_fn_snapshot_json(
           record: bool| {
         let py_fn_cloned = Python::with_gil(|py| py_fn.clone_ref(py));
 
-        let call_fn =
-            move |args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, _>>| -> SnapResult<PyObject> {
-                Python::with_gil(|py| py_fn_cloned.call(py, args, kwargs))
-                    .map_err(SnapError::from)
-            };
+        let call_fn = move |args: &Bound<'_, PyTuple>,
+                            kwargs: Option<&Bound<'_, _>>|
+              -> SnapResult<PyObject> {
+            Python::with_gil(|py| py_fn_cloned.call(py, args, kwargs)).map_err(SnapError::from)
+        };
 
         let wrapped_fn = snapshot_fn_auto_json!(
             call_fn, args, kwargs;

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -206,7 +206,7 @@ pub fn mock_json_snapshot(
 mod tests {
     use std::collections::HashMap;
 
-    use crate::RedactionType;
+    use crate::{RedactionType, SnapError, SnapResult};
     use insta::assert_json_snapshot as assert_json_snapshot_macro;
     use insta::internals::SnapshotContents;
     use insta::Snapshot;

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -6,6 +6,7 @@ use insta::Snapshot;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 
+use crate::errors::{SnapError, SnapResult};
 use crate::{RedactionType, SnapshotInfo};
 
 macro_rules! snapshot_fn_auto {
@@ -14,7 +15,7 @@ macro_rules! snapshot_fn_auto {
         let name = stringify!($f);
         let module_path = module_path!();
 
-        move |$( $arg ),+, info: &SnapshotInfo, redactions: Option<HashMap<String, RedactionType>>, record: bool| -> Result<_, anyhow::Error> {
+        move |$( $arg ),+, info: &SnapshotInfo, redactions: Option<HashMap<String, RedactionType>>, record: bool| -> SnapResult<_> {
             let finfo = SnapshotInfo {
                 snapshot_name: format!("{}_{}", info.snapshot_name, name),
                 ..info.clone()
@@ -41,15 +42,17 @@ macro_rules! snapshot_fn_auto {
                 Ok(result)
             } else {
                 match Snapshot::from_file(&snapshot_path)
-                    .map_err(|e| anyhow::anyhow!(e.to_string()))?
+                    .map_err(SnapError::from)?
                     .contents()
                 {
                     SnapshotContents::Text(content) => {
                         Ok(($result_from_str)(content.to_string())?)
                     },
-                    SnapshotContents::Binary(_) => Err(anyhow::anyhow!(
-                        "Snapshot at {:?} is binary, which is not supported for deserialization",
-                        snapshot_path
+                    SnapshotContents::Binary(_) => Err(SnapError::from(
+                        format!(
+                            "Snapshot at {:?} is binary, which is not supported for deserialization",
+                            snapshot_path
+                        ),
                     )),
                 }
             }
@@ -109,7 +112,7 @@ pub struct PyMockWrapper {
                 &'a SnapshotInfo,
                 Option<HashMap<String, RedactionType>>,
                 bool,
-            ) -> Result<Py<PyAny>, anyhow::Error>
+            ) -> SnapResult<Py<PyAny>>
             + Send
             + Sync,
     >,
@@ -146,7 +149,7 @@ fn wrap_py_fn_snapshot_json(
     &'b SnapshotInfo,
     Option<HashMap<String, RedactionType>>,
     bool,
-) -> Result<Py<PyAny>, anyhow::Error>
+) -> SnapResult<Py<PyAny>>
        + Send
        + Sync {
     move |args: &Bound<'_, PyTuple>,
@@ -157,18 +160,18 @@ fn wrap_py_fn_snapshot_json(
         let py_fn_cloned = Python::with_gil(|py| py_fn.clone_ref(py));
 
         let call_fn =
-            move |args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, _>>| -> PyResult<PyObject> {
+            move |args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, _>>| -> SnapResult<PyObject> {
                 Python::with_gil(|py| py_fn_cloned.call(py, args, kwargs))
+                    .map_err(SnapError::from)
             };
 
         let wrapped_fn = snapshot_fn_auto_json!(
             call_fn, args, kwargs;
             serialize_macro=assert_json_snapshot_depythonize;
-            result_from_str=|content: String| -> PyResult<PyObject> {
+            result_from_str=|content: String| -> SnapResult<PyObject> {
                 Python::with_gil(|py| {
-                    let value: serde_json::Value = serde_json::from_str(&content)
-                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-                    let obj = pythonize::pythonize(py, &value)?;
+                    let value: serde_json::Value = serde_json::from_str(&content)?;
+                    let obj = pythonize::pythonize(py, &value).map_err(SnapError::from)?;
                     Ok(obj.into())
                 })
             }
@@ -228,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_json_or_mock_creates_and_reads_snapshot() -> Result<(), anyhow::Error> {
+    fn test_snapshot_json_or_mock_creates_and_reads_snapshot() -> SnapResult<()> {
         let input_1 = 4;
 
         // Shared counter to track how many times the function is called
@@ -237,7 +240,7 @@ mod tests {
 
         let f = |i| {
             call_count_clone.set(call_count_clone.get() + 1);
-            Ok::<_, anyhow::Error>(i * 2)
+            Ok::<_, SnapError>(i * 2)
         };
 
         let snaphot_folder_path = snapshot_folder_path();
@@ -272,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_mocked_pyfn_creates_and_reads_snapshot() -> Result<(), anyhow::Error> {
+    fn test_create_mocked_pyfn_creates_and_reads_snapshot() -> SnapResult<()> {
         pyo3::prepare_freethreaded_python();
         let snapshot_info = SnapshotInfo {
             snapshot_name: "test_create_mocked_pyfn".to_string(),


### PR DESCRIPTION
## Summary
- add `errors.rs` module and define `SnapError`, `SnapResult`, and `PytestInfoError`
- remove `anyhow` from dependencies
- update snapshot mocking utilities to use new error type
- export errors in lib

## Testing
- `cargo check --locked` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*

------
https://chatgpt.com/codex/tasks/task_e_6884973bd348832393c5c99cc0f7ccd6