### PR TITLE
Handle insta panics gracefully

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@ use std::env::VarError;
 use std::fmt::{self, Display, Formatter};
 
 use pyo3::exceptions::PyValueError;
-use pyo3::PyErr;
+use pyo3::{PyErr, PyResult};
 use pythonize::PythonizeError;
 
 #[derive(Debug)]
@@ -125,3 +125,36 @@ impl From<PytestInfoError> for SnapError {
 }
 
 pub type SnapResult<T> = Result<T, SnapError>;
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Execute an Insta assertion, converting any panic into a `SnapError`.
+pub(crate) fn handle_insta_panic<F, T>(f: F) -> SnapResult<T>
+where
+    F: FnOnce() -> T + std::panic::UnwindSafe,
+{
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(v) => Ok(v),
+        Err(err) => {
+            let msg = if let Some(s) = err.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = err.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else {
+                "snapshot assertion failed".to_string()
+            };
+            Err(SnapError::Msg(msg))
+        }
+    }
+}
+
+/// Similar to [`handle_insta_panic`] but returns a `PyErr` directly.
+pub(crate) fn handle_insta_panic_py<F>(f: F) -> PyResult<()>
+where
+    F: FnOnce() + std::panic::UnwindSafe,
+{
+    handle_insta_panic(|| {
+        f();
+    })
+    .map_err(|e| pyo3::exceptions::PyAssertionError::new_err(e.to_string()))
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -131,7 +131,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 /// Execute an Insta assertion, converting any panic into a `SnapError`.
 pub(crate) fn handle_insta_panic<F, T>(f: F) -> SnapResult<T>
 where
-    F: FnOnce() -> T + std::panic::UnwindSafe,
+    F: FnOnce() -> T,
 {
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(v) => Ok(v),
@@ -151,7 +151,7 @@ where
 /// Similar to [`handle_insta_panic`] but returns a `PyErr` directly.
 pub(crate) fn handle_insta_panic_py<F>(f: F) -> PyResult<()>
 where
-    F: FnOnce() + std::panic::UnwindSafe,
+    F: FnOnce(),
 {
     handle_insta_panic(|| {
         f();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,11 @@ pub fn assert_json_snapshot(
         settings.add_redaction(selector.as_str(), redaction);
     }
 
-    settings.bind(|| {
-        insta::assert_json_snapshot!(snapshot_name, res);
-    });
-    Ok(())
+    handle_insta_panic_py(|| {
+        settings.bind(|| {
+            insta::assert_json_snapshot!(snapshot_name, res);
+        });
+    })
 }
 
 #[pyfunction]
@@ -67,10 +68,11 @@ pub fn assert_csv_snapshot(
         settings.add_redaction(selector.as_str(), redaction);
     }
 
-    settings.bind(|| {
-        insta::assert_csv_snapshot!(snapshot_name, res);
-    });
-    Ok(())
+    handle_insta_panic_py(|| {
+        settings.bind(|| {
+            insta::assert_csv_snapshot!(snapshot_name, res);
+        });
+    })
 }
 
 #[pyfunction]
@@ -81,20 +83,22 @@ pub fn assert_binary_snapshot(
 ) -> PyResult<()> {
     let snapshot_name = test_info.snapshot_name();
     let settings: insta::Settings = test_info.try_into()?;
-    settings.bind(|| {
-        insta::assert_binary_snapshot!(format!("{snapshot_name}.{extension}").as_str(), result);
-    });
-    Ok(())
+    handle_insta_panic_py(|| {
+        settings.bind(|| {
+            insta::assert_binary_snapshot!(format!("{snapshot_name}.{extension}").as_str(), result);
+        });
+    })
 }
 
 #[pyfunction]
 pub fn assert_snapshot(test_info: &SnapshotInfo, result: &Bound<'_, PyAny>) -> PyResult<()> {
     let snapshot_name = test_info.snapshot_name();
     let settings: insta::Settings = test_info.try_into()?;
-    settings.bind(|| {
-        insta::assert_snapshot!(snapshot_name, result);
-    });
-    Ok(())
+    handle_insta_panic_py(|| {
+        settings.bind(|| {
+            insta::assert_snapshot!(snapshot_name, result);
+        });
+    })
 }
 
 #[pymethods]

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -229,7 +229,7 @@ mod tests {
         Bound, IntoPyObject, Py, PyAny, PyResult, Python,
     };
 
-    use crate::{mock_json_snapshot, SnapshotInfo};
+    use crate::{handle_insta_panic, mock_json_snapshot, SnapshotInfo};
 
     fn snapshot_folder_path() -> PathBuf {
         // This env var points to the root of your crate during cargo test/build

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -6,7 +6,7 @@ use insta::Snapshot;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 
-use crate::errors::{SnapError, SnapResult};
+use crate::errors::{handle_insta_panic, SnapError, SnapResult};
 use crate::{RedactionType, SnapshotInfo};
 
 macro_rules! snapshot_fn_auto {
@@ -29,16 +29,23 @@ macro_rules! snapshot_fn_auto {
             }
 
             // Serialize the input using the passed closure
-            settings.bind(|| {
-                $serialize_macro!(format!("{snapshot_name}-request"), ($( $arg ),+));
-            });
+            handle_insta_panic(|| {
+                settings.bind(|| {
+                    $serialize_macro!(
+                        format!("{snapshot_name}-request"),
+                        ($( $arg ),+)
+                    );
+                });
+            })?;
 
 
             if record || !snapshot_path.exists() {
                 let result = f($( $arg ),+)?;
-                settings.bind(|| {
-                    $serialize_macro!(snapshot_name, result);
-                });
+                handle_insta_panic(|| {
+                    settings.bind(|| {
+                        $serialize_macro!(snapshot_name, result);
+                    });
+                })?;
                 Ok(result)
             } else {
                 match Snapshot::from_file(&snapshot_path)


### PR DESCRIPTION
## Summary
- capture panics from `insta` assertions
- expose helpers to convert those panics to Python errors
- use the helpers in assertion functions and macros

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*
- `cargo test` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6884e34024788323b74dfdbcf400db8a