### PR TITLE
Add docstrings in Google style

### DIFF
--- a/python/pysnaptest/__init__.py
+++ b/python/pysnaptest/__init__.py
@@ -1,3 +1,9 @@
+"""Public API for :mod:`pysnaptest`.
+
+This module re-exports the most commonly used helpers so they can be imported
+directly from ``pysnaptest``.
+"""
+
 # ruff: noqa: F401
 from .assertion import (
     snapshot,

--- a/python/pysnaptest/mocks.py
+++ b/python/pysnaptest/mocks.py
@@ -1,3 +1,9 @@
+"""Helpers for mocking functions while recording snapshot outputs.
+
+These utilities make it easy to patch or wrap functions so their returned values
+are automatically snapshot tested.
+"""
+
 from __future__ import annotations
 
 from typing import Callable, Dict, Optional
@@ -17,18 +23,45 @@ def mock_json_snapshot(
     redactions: Optional[Dict[str, str | int | None]] = None,
     allow_duplicates: bool = False,
 ):
+    """Return a function mock that snapshots its JSON result.
+
+    Args:
+        func: Function to wrap with snapshot behaviour.
+        record: Whether to record snapshots regardless of differences.
+        snapshot_path: Optional path override for storing the snapshot.
+        snapshot_name: Optional name override for the snapshot file.
+        redactions: Mapping of selectors to replacement values.
+        allow_duplicates: Whether to allow duplicate snapshot names.
+
+    Returns:
+        Callable: The wrapped function.
+    """
+
     test_info = extract_from_pytest_env(snapshot_path, snapshot_name, allow_duplicates)
     return _mock_json_snapshot(func, test_info, record, redactions)
 
 
 def resolve_function(dotted_path: str):
-    """Given a dotted path, import the module and return the attribute."""
+    """Resolve a dotted path to a callable.
+
+    Args:
+        dotted_path: ``module.attr`` style path to the target function.
+
+    Returns:
+        Callable: The resolved function object.
+    """
     module_path, attr_name = dotted_path.rsplit(".", 1)
     module = importlib.import_module(module_path)
     return getattr(module, attr_name)
 
 
 class patch_json_snapshot:
+    """Patch a function so calls are snapshot tested.
+
+    Instances of this class can be used as a context manager or decorator to
+    temporarily replace a target function with a snapshotting mock.
+    """
+
     def __init__(
         self,
         dotted_path: str,
@@ -39,6 +72,17 @@ class patch_json_snapshot:
         redactions: Optional[Dict[str, str | int | None]] = None,
         allow_duplicates: bool = False,
     ):
+        """Create the patch configuration.
+
+        Args:
+            dotted_path: ``module.attr`` style path to patch.
+            record: Whether to always record new snapshots.
+            snapshot_path: Optional path override for storing the snapshot.
+            snapshot_name: Optional name override for the snapshot file.
+            redactions: Mapping of selectors to replacement values.
+            allow_duplicates: Whether to allow duplicate snapshot names.
+        """
+
         self.dotted_path = dotted_path
         self.record = record
         self.snapshot_path = snapshot_path
@@ -48,6 +92,11 @@ class patch_json_snapshot:
         self._patcher = None
 
     def __enter__(self):
+        """Start patching and return the created mock.
+
+        Returns:
+            unittest.mock.MagicMock: The patched mock.
+        """
         original_fn = resolve_function(self.dotted_path)
         mocked_fn = mock_json_snapshot(
             original_fn,
@@ -62,9 +111,20 @@ class patch_json_snapshot:
         return self.mock
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Stop patching and clean up."""
+
         return self._patcher.__exit__(exc_type, exc_val, exc_tb)
 
     def __call__(self, func: Callable):
+        """Allow use of the object as a decorator.
+
+        Args:
+            func: The function being decorated.
+
+        Returns:
+            Callable: Wrapped function that applies the patch during execution.
+        """
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             with self:

--- a/python/pysnaptest/snapshot.py
+++ b/python/pysnaptest/snapshot.py
@@ -1,2 +1,4 @@
+"""Convenience re-export of snapshot helpers."""
+
 from .assertion import *
 from .mocks import *


### PR DESCRIPTION
## Summary
- re-export module docstring from __init__ with Google style
- document snapshot helpers and mocks using Google style docstrings
- update patch utilities with parameter descriptions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6884e2be985083238b36fabe448c6392