### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "pysnaptest"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "csv",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysnaptest"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 include = [
     "/pyproject.toml",

--- a/examples/my_project/requirements.txt
+++ b/examples/my_project/requirements.txt
@@ -1,3 +1,3 @@
-pysnaptest==0.1.0
+pysnaptest==0.4.0
 pytest==8.3.4
 pytest-env==1.1.5


### PR DESCRIPTION
## Summary
- bump version in Cargo.toml and lock file
- update example requirements to reference 0.4.0

## Testing
- `pip install -e .` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884f6438c888323868a1af1412c8fab