### PR TITLE
Fix assert_snapshot test

### DIFF
--- a/tests/snapshots/pysnaptest__test_snapshots_test_assert_snapshot@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_assert_snapshot@pysnap.snap
@@ -2,4 +2,4 @@
 source: src/lib.rs
 description: "Test File Path: tests/test_snapshots.py"
 ---
-"expected_result"
+expected_result

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -93,7 +93,7 @@ def test_assert_json_snapshot():
 
 
 def test_assert_snapshot():
-    assert_json_snapshot("expected_result")
+    assert_snapshot("expected_result")
 
 
 def test_assert_binary_snapshot():


### PR DESCRIPTION
## Summary
- use `assert_snapshot` in `test_assert_snapshot`
- update the corresponding snapshot

## Testing
- `pytest -k test_assert_snapshot -q` *(fails: ModuleNotFoundError: No module named 'pysnaptest')*

------
https://chatgpt.com/codex/tasks/task_e_6884f841955c832397ed631fa0aba554