### PR TITLE
Add Rust CI workflow and fix clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,25 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Test
+        run: cargo test

--- a/src/common.rs
+++ b/src/common.rs
@@ -262,7 +262,7 @@ mod tests {
             Some("snapshot_name_override".into()),
             false,
         )
-        .unwrap();
+        .expect("snapshot info from pytest should be valid");
         insta::assert_debug_snapshot!(snapshot_info);
         insta::assert_snapshot!(snapshot_info.snapshot_name(), @"snapshot_name_override");
         insta::assert_snapshot!(snapshot_info.last_snapshot_name(), @"snapshot_name_override");

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -309,16 +309,40 @@ def compute(x):
             let args = PyTuple::new(py, 7.into_pyobject(py))?;
 
             let result1: Bound<'_, PyDict> = wrapper.call1(args)?.extract()?;
-            assert_eq!(result1.get_item("result").unwrap().extract::<i32>()?, 70);
-            assert_eq!(result1.get_item("calls").unwrap().extract::<i32>()?, 1);
+            assert_eq!(
+                result1
+                    .get_item("result")
+                    .expect("result key missing")
+                    .extract::<i32>()?,
+                70
+            );
+            assert_eq!(
+                result1
+                    .get_item("calls")
+                    .expect("calls key missing")
+                    .extract::<i32>()?,
+                1
+            );
 
             let wrapper_obj = mock_json_snapshot(py_fn, snapshot_info.clone(), false, None)?;
             let wrapper = wrapper_obj.bind(py);
             let args = PyTuple::new(py, 7.into_pyobject(py))?;
 
             let result2: Bound<'_, PyDict> = wrapper.call1(args)?.extract()?;
-            assert_eq!(result2.get_item("result").unwrap().extract::<i32>()?, 70);
-            assert_eq!(result2.get_item("calls").unwrap().extract::<i32>()?, 1);
+            assert_eq!(
+                result2
+                    .get_item("result")
+                    .expect("result key missing")
+                    .extract::<i32>()?,
+                70
+            );
+            assert_eq!(
+                result2
+                    .get_item("calls")
+                    .expect("calls key missing")
+                    .extract::<i32>()?,
+                1
+            );
 
             Ok(())
         })?;


### PR DESCRIPTION
## Summary
- add new GitHub Actions workflow to run cargo fmt, clippy, and tests
- replace unwrap calls with expect to satisfy `clippy::unwrap_used`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` *(fails: libpython3.11.so.1.0: cannot open shared object file)*
- `apt-get update && apt-get install -y python3-dev` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f5221e6b883239864628273582a7e