### PR TITLE
feat: add Pydantic model snapshot support

### DIFF
--- a/python/pysnaptest/assertion.py
+++ b/python/pysnaptest/assertion.py
@@ -11,6 +11,11 @@ from typing import Callable, Any, Dict, overload, Union, Optional, TYPE_CHECKING
 from functools import partial, wraps
 import asyncio
 
+try:  # pragma: no cover - optional dependency
+    from pydantic import BaseModel  # type: ignore
+except Exception:  # pragma: no cover
+    BaseModel = None  # type: ignore
+
 from ._pysnaptest import (
     assert_json_snapshot as _assert_json_snapshot,
     assert_csv_snapshot as _assert_csv_snapshot,
@@ -86,6 +91,13 @@ def assert_json_snapshot(
         redactions: Mapping of selectors to replacement values.
         allow_duplicates: Whether to allow duplicate snapshot names.
     """
+
+    if BaseModel is not None and isinstance(result, BaseModel):
+        # Support Pydantic models by converting them to dictionaries before
+        # delegating to the Rust layer.  ``model_dump`` was introduced in
+        # Pydantic v2 but ``dict`` is still available in v1, so we prefer
+        # ``model_dump`` when present for forward compatibility.
+        result = result.model_dump() if hasattr(result, "model_dump") else result.dict()
 
     test_info = extract_from_pytest_env(snapshot_path, snapshot_name, allow_duplicates)
     _assert_json_snapshot(test_info, result, redactions)
@@ -356,7 +368,11 @@ def insta_snapshot(
         allow_duplicates: Whether to allow duplicate snapshot names.
     """
 
-    if isinstance(result, dict) or isinstance(result, list):
+    if BaseModel is not None and isinstance(result, BaseModel):
+        # Pydantic models should be treated as JSON snapshots by first
+        # converting them to standard Python dictionaries.
+        assert_json_snapshot(result, snapshot_path, snapshot_name, redactions)
+    elif isinstance(result, dict) or isinstance(result, list):
         assert_json_snapshot(result, snapshot_path, snapshot_name, redactions)
     elif isinstance(result, bytes):
         assert_binary_snapshot(

--- a/python/pysnaptest/mocks.py
+++ b/python/pysnaptest/mocks.py
@@ -11,6 +11,11 @@ import importlib
 from unittest.mock import patch
 import functools
 
+try:  # pragma: no cover - optional dependency
+    from pydantic import BaseModel  # type: ignore
+except Exception:  # pragma: no cover
+    BaseModel = None  # type: ignore
+
 from ._pysnaptest import mock_json_snapshot as _mock_json_snapshot, SnapshotInfo
 from .assertion import extract_from_pytest_env
 
@@ -38,7 +43,26 @@ def mock_json_snapshot(
     """
 
     test_info = extract_from_pytest_env(snapshot_path, snapshot_name, allow_duplicates)
-    return _mock_json_snapshot(func, test_info, record, redactions)
+
+    if BaseModel is not None:
+        # Wrap the original function so that any returned Pydantic model is
+        # converted to a plain dictionary prior to JSON serialization.
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            if isinstance(result, BaseModel):
+                return (
+                    result.model_dump()
+                    if hasattr(result, "model_dump")
+                    else result.dict()
+                )
+            return result
+
+        func_to_use = wrapper
+    else:
+        func_to_use = func
+
+    return _mock_json_snapshot(func_to_use, test_info, record, redactions)
 
 
 def resolve_function(dotted_path: str):

--- a/tests/snapshots/pysnaptest__mocks__test_snapshots_test_mock_json_snapshot_pydantic_model_build_model-request@pysnap.snap
+++ b/tests/snapshots/pysnaptest__mocks__test_snapshots_test_mock_json_snapshot_pydantic_model_build_model-request@pysnap.snap
@@ -1,0 +1,8 @@
+---
+source: src/mocks.rs
+description: "Test File Path: tests/test_snapshots.py"
+---
+{
+  "args": [],
+  "kwargs": null
+}

--- a/tests/snapshots/pysnaptest__mocks__test_snapshots_test_mock_json_snapshot_pydantic_model_build_model@pysnap.snap
+++ b/tests/snapshots/pysnaptest__mocks__test_snapshots_test_mock_json_snapshot_pydantic_model_build_model@pysnap.snap
@@ -1,0 +1,8 @@
+---
+source: src/mocks.rs
+description: "Test File Path: tests/test_snapshots.py"
+---
+{
+  "id": 1,
+  "name": "foo"
+}

--- a/tests/snapshots/pysnaptest__test_snapshots_test_assert_json_snapshot_pydantic_model@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_assert_json_snapshot_pydantic_model@pysnap.snap
@@ -1,0 +1,8 @@
+---
+source: src/lib.rs
+description: "Test File Path: tests/test_snapshots.py"
+---
+{
+  "id": 1,
+  "name": "foo"
+}

--- a/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_pydantic_model@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_pydantic_model@pysnap.snap
@@ -1,0 +1,8 @@
+---
+source: src/lib.rs
+description: "Test File Path: tests/test_snapshots.py"
+---
+{
+  "id": 1,
+  "name": "foo"
+}

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -20,6 +20,13 @@ from pysnaptest import (
 import pytest
 
 try:
+    from pydantic import BaseModel
+
+    PYDANTIC_UNAVAILABLE = False
+except ImportError:  # pragma: no cover
+    PYDANTIC_UNAVAILABLE = True
+
+try:
     import pandas as pd
 
     PANDAS_UNAVAILABLE = False
@@ -275,3 +282,37 @@ def test_mock_or_json_snapshot_redactions():
     assert result["sum"] == "[redacted]"
     assert result["x"] == 1
     assert result["y"] == 2
+
+
+@pytest.mark.skipif(PYDANTIC_UNAVAILABLE, reason="Pydantic is an optional dependency")
+@snapshot
+def test_snapshot_pydantic_model():
+    class Model(BaseModel):
+        id: int
+        name: str
+
+    return Model(id=1, name="foo")
+
+
+@pytest.mark.skipif(PYDANTIC_UNAVAILABLE, reason="Pydantic is an optional dependency")
+def test_assert_json_snapshot_pydantic_model():
+    class Model(BaseModel):
+        id: int
+        name: str
+
+    assert_json_snapshot(Model(id=1, name="foo"))
+
+
+@pytest.mark.skipif(PYDANTIC_UNAVAILABLE, reason="Pydantic is an optional dependency")
+def test_mock_json_snapshot_pydantic_model():
+    class Model(BaseModel):
+        id: int
+        name: str
+
+    def build_model() -> Model:
+        return Model(id=1, name="foo")
+
+    mocked = mock_json_snapshot(func=build_model)
+    result = mocked()
+    assert isinstance(result, dict)
+    assert result == {"id": 1, "name": "foo"}


### PR DESCRIPTION
## Summary
- support Pydantic `BaseModel` objects in snapshot assertions
- teach `mock_json_snapshot` to serialise Pydantic models
- exercise Pydantic support in tests

## Testing
- `INSTA_WORKSPACE_ROOT=tests pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1993974ac8323b1661f9b3cb329f7