### PR TITLE
Raise clean AssertionErrors and use concrete error types

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,7 +57,7 @@ pub enum SnapError {
     Py(PyErr),
     PytestInfo(PytestInfoError),
     Pythonize(PythonizeError),
-    Other(Box<dyn std::error::Error>),
+    Insta(String),
 }
 
 impl Display for SnapError {
@@ -69,12 +69,22 @@ impl Display for SnapError {
             SnapError::Py(e) => write!(f, "{e}"),
             SnapError::PytestInfo(e) => write!(f, "{e}"),
             SnapError::Pythonize(e) => write!(f, "{e}"),
-            SnapError::Other(e) => write!(f, "{e}"),
+            SnapError::Insta(e) => write!(f, "{e}"),
         }
     }
 }
 
 impl std::error::Error for SnapError {}
+
+impl SnapError {
+    /// Builds an [`SnapError::Insta`] from any displayable error.
+    ///
+    /// insta's file APIs return a boxed `dyn Error`; this captures the message
+    /// as a concrete `String` so `SnapError` never stores a type-erased error.
+    pub fn insta(err: impl Display) -> Self {
+        SnapError::Insta(err.to_string())
+    }
+}
 
 impl From<String> for SnapError {
     fn from(value: String) -> Self {
@@ -97,12 +107,6 @@ impl From<std::io::Error> for SnapError {
 impl From<PythonizeError> for SnapError {
     fn from(value: PythonizeError) -> Self {
         SnapError::Pythonize(value)
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for SnapError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        SnapError::Other(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use pyo3::{
 mod common;
 mod errors;
 mod mocks;
+mod panic;
 
 pub use common::*;
 pub use errors::*;
@@ -17,6 +18,7 @@ pub use mocks::*;
 use std::{collections::HashMap, path::PathBuf};
 
 use csv::ReaderBuilder;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -34,10 +36,12 @@ pub fn assert_json_snapshot(
         settings.add_redaction(selector.as_str(), redaction);
     }
 
-    settings.bind(|| {
-        insta::assert_json_snapshot!(snapshot_name, res);
-    });
-    Ok(())
+    let snapshot_label = snapshot_name.clone();
+    panic::run_snapshot_assertion(&snapshot_label, || {
+        settings.bind(|| {
+            insta::assert_json_snapshot!(snapshot_name, res);
+        });
+    })
 }
 
 #[pyfunction]
@@ -50,14 +54,14 @@ pub fn assert_csv_snapshot(
     let mut rdr = ReaderBuilder::new().from_reader(result.as_bytes());
     let columns: Vec<Vec<serde_json::Value>> = vec![rdr
         .headers()
-        .expect("Expects csv with headers")
+        .map_err(|e| PyValueError::new_err(format!("Failed to read CSV headers: {e}")))?
         .into_iter()
         .map(|h| h.into())
         .collect()];
     let records = rdr
         .into_deserialize()
         .collect::<Result<Vec<Vec<serde_json::Value>>, _>>()
-        .expect("Failed to parse csv records");
+        .map_err(|e| PyValueError::new_err(format!("Failed to parse CSV records: {e}")))?;
     let res: Vec<Vec<serde_json::Value>> = columns.into_iter().chain(records).collect();
 
     let snapshot_name = test_info.snapshot_name();
@@ -67,10 +71,12 @@ pub fn assert_csv_snapshot(
         settings.add_redaction(selector.as_str(), redaction);
     }
 
-    settings.bind(|| {
-        insta::assert_csv_snapshot!(snapshot_name, res);
-    });
-    Ok(())
+    let snapshot_label = snapshot_name.clone();
+    panic::run_snapshot_assertion(&snapshot_label, || {
+        settings.bind(|| {
+            insta::assert_csv_snapshot!(snapshot_name, res);
+        });
+    })
 }
 
 #[pyfunction]
@@ -81,20 +87,24 @@ pub fn assert_binary_snapshot(
 ) -> PyResult<()> {
     let snapshot_name = test_info.snapshot_name();
     let settings: insta::Settings = test_info.try_into()?;
-    settings.bind(|| {
-        insta::assert_binary_snapshot!(format!("{snapshot_name}.{extension}").as_str(), result);
-    });
-    Ok(())
+    let snapshot_label = snapshot_name.clone();
+    panic::run_snapshot_assertion(&snapshot_label, || {
+        settings.bind(|| {
+            insta::assert_binary_snapshot!(format!("{snapshot_name}.{extension}").as_str(), result);
+        });
+    })
 }
 
 #[pyfunction]
 pub fn assert_snapshot(test_info: &SnapshotInfo, result: &Bound<'_, PyAny>) -> PyResult<()> {
     let snapshot_name = test_info.snapshot_name();
     let settings: insta::Settings = test_info.try_into()?;
-    settings.bind(|| {
-        insta::assert_snapshot!(snapshot_name, result);
-    });
-    Ok(())
+    let snapshot_label = snapshot_name.clone();
+    panic::run_snapshot_assertion(&snapshot_label, || {
+        settings.bind(|| {
+            insta::assert_snapshot!(snapshot_name, result);
+        });
+    })
 }
 
 #[pymethods]

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -42,7 +42,7 @@ macro_rules! snapshot_fn_auto {
                 Ok(result)
             } else {
                 match Snapshot::from_file(&snapshot_path)
-                    .map_err(SnapError::from)?
+                    .map_err(SnapError::insta)?
                     .contents()
                 {
                     SnapshotContents::Text(content) => {

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,107 @@
+//! Converts insta's snapshot-mismatch panics into clean Python `AssertionError`s.
+//!
+//! insta only exposes *panicking* assertion macros: a mismatch is signalled by
+//! `panic!("snapshot assertion for '...' failed in line N")`, and its internal
+//! non-panicking entry point is not part of the public API. So the only
+//! supported way to wrap insta in a library is to run the assertion, catch the
+//! unwind, and turn it into an exception.
+//!
+//! Left alone, that panic surfaces to Python as a `pyo3_runtime.PanicException`,
+//! and Rust's default hook first prints a `thread '<unnamed>' panicked at ...
+//! note: run with RUST_BACKTRACE=1` line to stderr. Both are noise for a Python
+//! user, who just wants the diff and a normal assertion failure. We install a
+//! panic hook that stays quiet while one of our assertions is running and raise
+//! a plain `AssertionError` instead.
+
+use std::any::Any;
+use std::cell::Cell;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Once;
+
+use pyo3::exceptions::PyAssertionError;
+use pyo3::PyResult;
+
+thread_local! {
+    /// Set while one of our snapshot assertions is running, so the panic hook
+    /// knows to stay silent for the expected mismatch panic.
+    static IN_ASSERTION: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Installs (once) a panic hook that suppresses stderr output while one of our
+/// snapshot assertions is running, and otherwise defers to the previous hook.
+fn install_quiet_hook() {
+    static HOOK: Once = Once::new();
+    HOOK.call_once(|| {
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            if !IN_ASSERTION.with(Cell::get) {
+                previous(info);
+            }
+        }));
+    });
+}
+
+/// Marks the current thread as running a snapshot assertion, clearing the flag
+/// again on drop so it is reset even if the assertion unwinds.
+struct AssertionGuard;
+
+impl AssertionGuard {
+    fn enter() -> Self {
+        install_quiet_hook();
+        IN_ASSERTION.with(|flag| flag.set(true));
+        AssertionGuard
+    }
+}
+
+impl Drop for AssertionGuard {
+    fn drop(&mut self) {
+        IN_ASSERTION.with(|flag| flag.set(false));
+    }
+}
+
+/// Extracts a human-readable message from a panic payload, if it carries one.
+fn panic_message(payload: &(dyn Any + Send)) -> Option<String> {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        Some((*s).to_string())
+    } else {
+        payload.downcast_ref::<String>().cloned()
+    }
+}
+
+/// Builds the `AssertionError` message for a failed assertion.
+///
+/// insta's mismatch panic is `snapshot assertion for '...' failed in line N`,
+/// where the line number points at Rust internals and is noise for a Python
+/// user; that case gets a friendly hint. Any other panic (an unexpected bug)
+/// keeps its original message.
+fn assertion_message(snapshot_name: &str, payload: &(dyn Any + Send)) -> String {
+    let raw = panic_message(payload);
+    if raw
+        .as_deref()
+        .is_some_and(|m| m.starts_with("snapshot assertion for"))
+    {
+        format!(
+            "snapshot '{snapshot_name}' did not match the stored value (see the diff above). \
+             Update the snapshot if this change is intentional."
+        )
+    } else {
+        raw.unwrap_or_else(|| format!("snapshot '{snapshot_name}' assertion failed"))
+    }
+}
+
+/// Runs an insta assertion, turning a snapshot mismatch (which insta signals by
+/// panicking) into a Python `AssertionError`. insta prints the diff to stdout
+/// before it panics, so the raised error only needs to say what to do next.
+pub fn run_snapshot_assertion<F: FnOnce()>(snapshot_name: &str, assertion: F) -> PyResult<()> {
+    let guard = AssertionGuard::enter();
+    let outcome = panic::catch_unwind(AssertUnwindSafe(assertion));
+    drop(guard);
+
+    match outcome {
+        Ok(()) => Ok(()),
+        Err(payload) => Err(PyAssertionError::new_err(assertion_message(
+            snapshot_name,
+            payload.as_ref(),
+        ))),
+    }
+}


### PR DESCRIPTION
Snapshot mismatches previously surfaced as a scary `pyo3_runtime.PanicException` plus a `thread '<unnamed>' panicked at insta/runtime.rs ... note: run with RUST_BACKTRACE=1` dump on stderr, because insta signals a mismatch by panicking. A new `panic` module installs a hook that silences that stderr noise for our own assertions and converts the unwound panic into a native Python `AssertionError` with actionable guidance; insta's diff is still printed to stdout.

Also replace the two CSV `.expect(...)` calls (which panicked on malformed input) with `map_err` into `PyValueError`, and drop the type-erased `SnapError::Other(Box<dyn Error>)` catch-all in favour of a concrete `SnapError::Insta(String)` variant so every error case is a type we own.