### PR TITLE
Add cargo-free snapshot review workflow and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ at a time, showing insta's own diff and prompting to accept, reject, or skip:
 
 ```bash
 pytest --snapshot-new          # record changed snapshots as pending files
-python -m pysnaptest review    # interactively review each pending snapshot
+pysnaptest review              # interactively review each pending snapshot
 ```
 
 You can also act on all pending snapshots at once:
 
 ```bash
-python -m pysnaptest pending   # list pending snapshots with their diffs
-python -m pysnaptest accept    # accept every pending snapshot
-python -m pysnaptest reject    # discard every pending snapshot
+pysnaptest pending             # list pending snapshots with their diffs
+pysnaptest accept              # accept every pending snapshot
+pysnaptest reject              # discard every pending snapshot
 ```
 
 The diffs shown by `review` and `pending` are rendered by insta itself, so they

--- a/README.md
+++ b/README.md
@@ -59,11 +59,59 @@ def test_use_http_request():
 
 ## Updating Snapshots
 
-If the output changes intentionally, you can review and update snapshots using
-`cargo-insta review`. The tool used for this, `cargo-insta`, is distributed via
-Rust's package manager `cargo`.
+If the output changes intentionally, you can review and update snapshots in two
+ways: with the built-in, cargo-free workflow (recommended for Python projects)
+or with `cargo-insta review`.
 
-### Installing `cargo-insta`
+### Reviewing without cargo (recommended)
+
+`pysnaptest` ships a pytest plugin and a small CLI so you can create, update, and
+accept snapshots without installing any Rust tooling. insta itself does the work
+of diffing and writing snapshots; the plugin only selects the update mode.
+
+Update snapshots in place while running your tests (they pass on update, just
+like other Python snapshot tools):
+
+```bash
+pytest --snapshot-update
+```
+
+Prefer to inspect changes and accept them yourself? Record pending `*.snap.new`
+files instead, then review them the way `cargo insta review` does — one snapshot
+at a time, showing insta's own diff and prompting to accept, reject, or skip:
+
+```bash
+pytest --snapshot-new          # record changed snapshots as pending files
+python -m pysnaptest review    # interactively review each pending snapshot
+```
+
+You can also act on all pending snapshots at once:
+
+```bash
+python -m pysnaptest pending   # list pending snapshots with their diffs
+python -m pysnaptest accept    # accept every pending snapshot
+python -m pysnaptest reject    # discard every pending snapshot
+```
+
+The diffs shown by `review` and `pending` are rendered by insta itself, so they
+match exactly what you see from a failing assertion or `cargo insta review`.
+
+You can also drive this from Python:
+
+```python
+from pysnaptest import find_pending_snapshots, accept_pending_snapshot
+
+for pending in find_pending_snapshots():
+    accept_pending_snapshot(pending)
+```
+
+Set `INSTA_WORKSPACE_ROOT` so both the plugin and the CLI agree on where
+snapshots live (see the example project's `pytest.ini`).
+
+### Reviewing with `cargo-insta`
+
+You can also use the [`cargo-insta`](https://insta.rs/) reviewer, which is
+distributed via Rust's package manager `cargo`.
 
 1. Install Rust using [rustup](https://rustup.rs/) if it is not already present.
 2. Install the CLI with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ pandas = ["pandas>=0.12.0"]
 polars = ["polars>=0.18"]
 pyarrow = ["pyarrow>=17.0.0"]
 
+[project.scripts]
+pysnaptest = "pysnaptest.__main__:main"
+
+[project.entry-points.pytest11]
+pysnaptest = "pysnaptest.pytest_plugin"
+
 [tool.maturin]
 bindings = 'pyo3'
 features = ["pyo3/extension-module"]

--- a/python/pysnaptest/__init__.py
+++ b/python/pysnaptest/__init__.py
@@ -17,4 +17,13 @@ from .assertion import (
     extract_from_pytest_env,
 )
 from .mocks import mock_json_snapshot, patch_json_snapshot
+from .review import (
+    find_pending_snapshots,
+    accept_pending_snapshot,
+    reject_pending_snapshot,
+    print_pending_diff,
+    accept_all,
+    reject_all,
+    review,
+)
 from ._pysnaptest import PySnapshot

--- a/python/pysnaptest/__main__.py
+++ b/python/pysnaptest/__main__.py
@@ -1,0 +1,75 @@
+"""Command-line entry point for reviewing pending snapshots.
+
+Run ``python -m pysnaptest --help`` for usage. Mirrors the common
+``cargo insta`` subcommands (``review``, ``accept``, ``reject``,
+``pending-snapshots``) but works without any Rust tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional, Sequence
+
+from .review import (
+    accept_all,
+    find_pending_snapshots,
+    print_pending_diff,
+    reject_all,
+    review,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the ``pysnaptest`` CLI."""
+
+    parser = argparse.ArgumentParser(
+        prog="pysnaptest",
+        description="Review, accept, or reject pending snapshots without cargo-insta.",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Directory to search for pending snapshots "
+        "(defaults to $INSTA_WORKSPACE_ROOT or the current directory).",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("review", help="Interactively review each pending snapshot.")
+    sub.add_parser("accept", help="Accept all pending snapshots.")
+    sub.add_parser("reject", help="Reject all pending snapshots.")
+    sub.add_parser("pending", help="List pending snapshots and their diffs.")
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the CLI.
+
+    Args:
+        argv: Optional argument list (defaults to ``sys.argv``).
+
+    Returns:
+        int: Process exit code.
+    """
+
+    args = build_parser().parse_args(argv)
+
+    if args.command == "accept":
+        written = accept_all(args.root)
+        print(f"Accepted {len(written)} snapshot(s).")
+    elif args.command == "reject":
+        count = reject_all(args.root)
+        print(f"Rejected {count} snapshot(s).")
+    elif args.command == "pending":
+        pending = find_pending_snapshots(args.root)
+        for path in pending:
+            print(f"\n{path}")
+            print_pending_diff(path, args.root)
+        print(f"\n{len(pending)} pending snapshot(s).")
+    else:  # "review" or no subcommand
+        review(args.root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/python/pysnaptest/__main__.py
+++ b/python/pysnaptest/__main__.py
@@ -1,6 +1,6 @@
 """Command-line entry point for reviewing pending snapshots.
 
-Run ``python -m pysnaptest --help`` for usage. Mirrors the common
+Run ``pysnaptest --help`` for usage. Mirrors the common
 ``cargo insta`` subcommands (``review``, ``accept``, ``reject``,
 ``pending-snapshots``) but works without any Rust tooling.
 """
@@ -72,4 +72,3 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/python/pysnaptest/pytest_plugin.py
+++ b/python/pysnaptest/pytest_plugin.py
@@ -7,7 +7,7 @@ snapshot-management flags to ``pytest``:
   ``INSTA_UPDATE=always`` before any assertion runs).
 * ``--snapshot-new`` — record changed/new snapshots as pending ``*.snap.new``
   files instead (sets ``INSTA_UPDATE=new``); accept them with
-  ``python -m pysnaptest accept``.
+  ``pysnaptest accept``.
 
 insta does the actual work (diffing, writing, format); this plugin only selects
 the update mode. The environment variable is set in :func:`pytest_configure`,
@@ -56,6 +56,3 @@ def pytest_configure(config: "pytest.Config") -> None:
         os.environ["INSTA_UPDATE"] = "always"
     elif config.getoption("--snapshot-new"):
         os.environ["INSTA_UPDATE"] = "new"
-
-
-

--- a/python/pysnaptest/pytest_plugin.py
+++ b/python/pysnaptest/pytest_plugin.py
@@ -1,0 +1,61 @@
+"""Pytest plugin for pysnaptest.
+
+Registered via the ``pytest11`` entry point, this plugin adds cargo-free
+snapshot-management flags to ``pytest``:
+
+* ``--snapshot-update`` — update snapshots in place and pass (sets
+  ``INSTA_UPDATE=always`` before any assertion runs).
+* ``--snapshot-new`` — record changed/new snapshots as pending ``*.snap.new``
+  files instead (sets ``INSTA_UPDATE=new``); accept them with
+  ``python -m pysnaptest accept``.
+
+insta does the actual work (diffing, writing, format); this plugin only selects
+the update mode. The environment variable is set in :func:`pytest_configure`,
+which runs before the first assertion — insta caches its update configuration
+per workspace on first read, so setting it any later would have no effect.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def pytest_addoption(parser: "pytest.Parser") -> None:
+    """Register pysnaptest's command-line options."""
+
+    group = parser.getgroup("pysnaptest", "snapshot testing (pysnaptest)")
+    group.addoption(
+        "--snapshot-update",
+        action="store_true",
+        default=False,
+        help="Update snapshots in place and pass (INSTA_UPDATE=always).",
+    )
+    group.addoption(
+        "--snapshot-new",
+        action="store_true",
+        default=False,
+        help="Record changed snapshots as pending *.snap.new files (INSTA_UPDATE=new).",
+    )
+
+
+def pytest_configure(config: "pytest.Config") -> None:
+    """Set the insta update mode before any assertion runs.
+
+    ``--snapshot-update`` takes precedence over ``--snapshot-new`` if both are
+    given. An ``INSTA_UPDATE`` value already present in the environment is left
+    untouched so explicit user configuration wins.
+    """
+
+    if os.environ.get("INSTA_UPDATE"):
+        return
+    if config.getoption("--snapshot-update"):
+        os.environ["INSTA_UPDATE"] = "always"
+    elif config.getoption("--snapshot-new"):
+        os.environ["INSTA_UPDATE"] = "new"
+
+
+

--- a/python/pysnaptest/review.py
+++ b/python/pysnaptest/review.py
@@ -1,0 +1,149 @@
+"""Cargo-free helpers to accept or reject pending snapshots.
+
+When pytest is run with ``--snapshot-new`` (``INSTA_UPDATE=new``), insta writes
+pending ``*@pysnap.snap.new`` files for changed snapshots and prints the diff at
+assertion time. These helpers persist or discard those pending files through
+insta's own ``Snapshot::save`` so the committed format stays correct.
+
+For an interactive diff viewer, use ``cargo-insta review``; this module
+deliberately does not re-implement diffing or a review UI.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from ._pysnaptest import (
+    accept_pending_snapshot as _accept_pending_snapshot,
+    reject_pending_snapshot as _reject_pending_snapshot,
+    print_pending_diff as _print_pending_diff,
+)
+
+#: Glob that matches only pysnaptest's own pending snapshots, so review never
+#: touches pending files produced by other snapshot tools.
+PENDING_GLOB = "**/*@pysnap.snap.new"
+
+
+def _root(root: Optional[str]) -> Path:
+    return Path(root or os.environ.get("INSTA_WORKSPACE_ROOT") or ".")
+
+
+def find_pending_snapshots(root: Optional[str] = None) -> List[Path]:
+    """Find pending pysnaptest snapshots under ``root``.
+
+    Args:
+        root: Directory to search. Defaults to ``INSTA_WORKSPACE_ROOT`` if set,
+            otherwise the current working directory.
+
+    Returns:
+        List[Path]: Sorted paths to ``*@pysnap.snap.new`` pending snapshots.
+    """
+
+    return sorted(_root(root).glob(PENDING_GLOB))
+
+
+def accept_pending_snapshot(pending_path: str | Path) -> Path:
+    """Accept a pending snapshot, persisting it to its ``.snap`` file.
+
+    Args:
+        pending_path: Path to a ``*@pysnap.snap.new`` file.
+
+    Returns:
+        Path: The target ``.snap`` path that was written.
+    """
+
+    return Path(_accept_pending_snapshot(str(pending_path)))
+
+
+def reject_pending_snapshot(pending_path: str | Path) -> None:
+    """Reject a pending snapshot, deleting its ``.snap.new`` file.
+
+    Args:
+        pending_path: Path to a ``*@pysnap.snap.new`` file.
+    """
+
+    _reject_pending_snapshot(str(pending_path))
+
+
+def print_pending_diff(
+    pending_path: str | Path, root: Optional[str] = None
+) -> None:
+    """Print insta's own diff for a pending snapshot against its committed target.
+
+    Args:
+        pending_path: Path to a ``*@pysnap.snap.new`` file.
+        root: Workspace root used to display relative paths. Defaults to
+            ``INSTA_WORKSPACE_ROOT`` if set, otherwise the current directory.
+    """
+
+    _print_pending_diff(str(pending_path), str(_root(root)))
+
+
+def accept_all(root: Optional[str] = None) -> List[Path]:
+    """Accept every pending snapshot under ``root``.
+
+    Args:
+        root: Directory to search. See :func:`find_pending_snapshots`.
+
+    Returns:
+        List[Path]: The target ``.snap`` paths that were written.
+    """
+
+    return [accept_pending_snapshot(p) for p in find_pending_snapshots(root)]
+
+
+def reject_all(root: Optional[str] = None) -> int:
+    """Reject every pending snapshot under ``root``.
+
+    Args:
+        root: Directory to search. See :func:`find_pending_snapshots`.
+
+    Returns:
+        int: The number of pending snapshots rejected.
+    """
+
+    pending = find_pending_snapshots(root)
+    for p in pending:
+        reject_pending_snapshot(p)
+    return len(pending)
+
+
+def review(root: Optional[str] = None) -> int:
+    """Interactively review pending snapshots, one at a time.
+
+    Mirrors ``cargo insta review``: for each pending snapshot insta's own diff
+    is shown, then you accept, reject, or skip it.
+
+    Args:
+        root: Directory to search. See :func:`find_pending_snapshots`.
+
+    Returns:
+        int: The number of pending snapshots that were accepted.
+    """
+
+    pending = find_pending_snapshots(root)
+    if not pending:
+        print("No pending snapshots.")
+        return 0
+
+    accepted = 0
+    for index, path in enumerate(pending, start=1):
+        print(f"\nReviewing [{index}/{len(pending)}]:")
+        print_pending_diff(path, root)
+        while True:
+            choice = input("  [a]ccept  [r]eject  [s]kip  [q]uit? ").strip().lower()
+            if choice in {"a", "accept"}:
+                accept_pending_snapshot(path)
+                accepted += 1
+                break
+            if choice in {"r", "reject"}:
+                reject_pending_snapshot(path)
+                break
+            if choice in {"s", "skip", ""}:
+                break
+            if choice in {"q", "quit"}:
+                return accepted
+    return accepted
+

--- a/python/pysnaptest/review.py
+++ b/python/pysnaptest/review.py
@@ -67,9 +67,7 @@ def reject_pending_snapshot(pending_path: str | Path) -> None:
     _reject_pending_snapshot(str(pending_path))
 
 
-def print_pending_diff(
-    pending_path: str | Path, root: Optional[str] = None
-) -> None:
+def print_pending_diff(pending_path: str | Path, root: Optional[str] = None) -> None:
     """Print insta's own diff for a pending snapshot against its committed target.
 
     Args:
@@ -146,4 +144,3 @@ def review(root: Optional[str] = None) -> int:
             if choice in {"q", "quit"}:
                 return accepted
     return accepted
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,14 @@ pub use common::*;
 pub use errors::*;
 pub use mocks::*;
 
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use csv::ReaderBuilder;
+use insta::output::SnapshotPrinter;
+use insta::Snapshot;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -107,6 +112,109 @@ pub fn assert_snapshot(test_info: &SnapshotInfo, result: &Bound<'_, PyAny>) -> P
     })
 }
 
+/// Removes a pending `.snap.new` file and, for binary snapshots, its sidecar data file.
+fn remove_pending_files(pending_path: &Path, snapshot: &Snapshot) -> PyResult<()> {
+    if let Some(binary_sidecar) = snapshot.build_binary_path(pending_path) {
+        if binary_sidecar.exists() {
+            std::fs::remove_file(&binary_sidecar).map_err(|e| {
+                PyValueError::new_err(format!(
+                    "Unable to remove pending binary sidecar {binary_sidecar:?}: {e}"
+                ))
+            })?;
+        }
+    }
+    std::fs::remove_file(pending_path).map_err(|e| {
+        PyValueError::new_err(format!(
+            "Unable to remove pending snapshot {pending_path:?}: {e}"
+        ))
+    })
+}
+
+/// Ensures a path is a pending snapshot file (has a trailing `.new` extension).
+fn ensure_pending(pending_path: &Path) -> PyResult<()> {
+    if pending_path.extension().and_then(|e| e.to_str()) == Some("new") {
+        Ok(())
+    } else {
+        Err(PyValueError::new_err(format!(
+            "Not a pending snapshot file (expected a trailing '.new'): {pending_path:?}"
+        )))
+    }
+}
+
+/// Accepts a pending snapshot by persisting it to its target `.snap` file.
+///
+/// The pending snapshot is loaded through insta so the committed snapshot is written with the
+/// correct format (pending-only metadata is trimmed and binary sidecars are handled). The pending
+/// `.snap.new` file (and any binary sidecar) is removed afterwards. Returns the target path.
+#[pyfunction]
+pub fn accept_pending_snapshot(pending_path: PathBuf) -> PyResult<PathBuf> {
+    ensure_pending(&pending_path)?;
+    let target = pending_path.with_extension("");
+    let snapshot = Snapshot::from_file(&pending_path).map_err(|e| {
+        PyValueError::new_err(format!(
+            "Unable to load pending snapshot from {pending_path:?}, details: {e}"
+        ))
+    })?;
+    snapshot.save(&target).map_err(|e| {
+        PyValueError::new_err(format!("Unable to save snapshot to {target:?}, details: {e}"))
+    })?;
+    remove_pending_files(&pending_path, &snapshot)?;
+    Ok(target)
+}
+
+/// Rejects a pending snapshot by deleting its `.snap.new` file (and any binary sidecar).
+#[pyfunction]
+pub fn reject_pending_snapshot(pending_path: PathBuf) -> PyResult<()> {
+    ensure_pending(&pending_path)?;
+    match Snapshot::from_file(&pending_path) {
+        Ok(snapshot) => remove_pending_files(&pending_path, &snapshot),
+        // A corrupt/unreadable pending file still needs to be cleared.
+        Err(_) => std::fs::remove_file(&pending_path).map_err(|e| {
+            PyValueError::new_err(format!(
+                "Unable to remove pending snapshot {pending_path:?}: {e}"
+            ))
+        }),
+    }
+}
+
+/// Prints insta's own diff for a pending snapshot against its committed target.
+///
+/// This renders the exact colored diff insta shows during a failing assertion, so the
+/// review workflow leans on insta rather than re-implementing diffing.
+#[pyfunction]
+#[pyo3(signature = (pending_path, workspace_root=None))]
+pub fn print_pending_diff(pending_path: PathBuf, workspace_root: Option<PathBuf>) -> PyResult<()> {
+    ensure_pending(&pending_path)?;
+    let new_snapshot = Snapshot::from_file(&pending_path).map_err(|e| {
+        PyValueError::new_err(format!(
+            "Unable to load pending snapshot from {pending_path:?}, details: {e}"
+        ))
+    })?;
+    let target = pending_path.with_extension("");
+    let old_snapshot = if target.exists() {
+        Some(Snapshot::from_file(&target).map_err(|e| {
+            PyValueError::new_err(format!("Unable to load snapshot from {target:?}, details: {e}"))
+        })?)
+    } else {
+        None
+    };
+    let root = workspace_root
+        .or_else(|| std::env::var_os("INSTA_WORKSPACE_ROOT").map(PathBuf::from))
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let title = new_snapshot
+        .snapshot_name()
+        .unwrap_or("snapshot")
+        .to_string();
+    let mut printer = SnapshotPrinter::new(&root, old_snapshot.as_ref(), &new_snapshot);
+    printer.set_show_diff(true);
+    printer.set_show_info(true);
+    printer.set_title(Some(&title));
+    printer.set_snapshot_file(Some(&target));
+    printer.print();
+    Ok(())
+}
+
 #[pymethods]
 impl SnapshotInfo {
     #[staticmethod]
@@ -193,6 +301,9 @@ fn pysnaptest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(assert_json_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_csv_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(mock_json_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(accept_pending_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(reject_pending_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(print_pending_diff, m)?)?;
     m.add_class::<PySnapshot>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,9 @@ pub fn accept_pending_snapshot(pending_path: PathBuf) -> PyResult<PathBuf> {
         ))
     })?;
     snapshot.save(&target).map_err(|e| {
-        PyValueError::new_err(format!("Unable to save snapshot to {target:?}, details: {e}"))
+        PyValueError::new_err(format!(
+            "Unable to save snapshot to {target:?}, details: {e}"
+        ))
     })?;
     remove_pending_files(&pending_path, &snapshot)?;
     Ok(target)
@@ -193,7 +195,9 @@ pub fn print_pending_diff(pending_path: PathBuf, workspace_root: Option<PathBuf>
     let target = pending_path.with_extension("");
     let old_snapshot = if target.exists() {
         Some(Snapshot::from_file(&target).map_err(|e| {
-            PyValueError::new_err(format!("Unable to load snapshot from {target:?}, details: {e}"))
+            PyValueError::new_err(format!(
+                "Unable to load snapshot from {target:?}, details: {e}"
+            ))
         })?)
     } else {
         None

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,134 @@
+"""Tests for the cargo-free review workflow (pytest plugin, CLI, and helpers)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from pysnaptest import (
+    accept_pending_snapshot,
+    find_pending_snapshots,
+    print_pending_diff,
+    reject_pending_snapshot,
+)
+
+
+def _write_project(tmp_path: Path, value: str) -> None:
+    (tmp_path / "test_demo.py").write_text(
+        "from pysnaptest import assert_snapshot\n"
+        "def test_demo():\n"
+        f"    assert_snapshot({value!r})\n"
+    )
+
+
+def _run_pytest(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    # Disable bytecode caching so rewriting test_demo.py within the same
+    # filesystem timestamp never reuses a stale .pyc (a test-harness artifact,
+    # not something real edits hit).
+    env = {
+        **os.environ,
+        "INSTA_WORKSPACE_ROOT": str(tmp_path),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "test_demo.py", "-q", *args],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_pending(tmp_path: Path, value: str = "VERSION_A") -> Path:
+    """Create a genuine pending snapshot via a subprocess run and return its path."""
+
+    _write_project(tmp_path, value)
+    result = _run_pytest(tmp_path, "--snapshot-new")
+    assert result.returncode != 0, result.stdout + result.stderr
+    pending = find_pending_snapshots(str(tmp_path))
+    assert len(pending) == 1, pending
+    return pending[0]
+
+
+def test_find_pending_snapshots_ignores_foreign(tmp_path: Path) -> None:
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "mod__test@pysnap.snap.new").write_text("---\n---\nx\n")
+    (snapshots / "foreign.snap.new").write_text("not ours")
+    (snapshots / "mod__test@pysnap.snap").write_text("committed")
+
+    found = find_pending_snapshots(str(tmp_path))
+
+    assert [p.name for p in found] == ["mod__test@pysnap.snap.new"]
+
+
+def test_accept_persists_and_cleans_up(tmp_path: Path) -> None:
+    pending = _make_pending(tmp_path, "VERSION_A")
+
+    target = accept_pending_snapshot(pending)
+
+    assert target.exists()
+    assert not pending.exists()
+    # The committed snapshot now satisfies the assertion.
+    rerun = _run_pytest(tmp_path)
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
+
+
+def test_reject_deletes_pending(tmp_path: Path) -> None:
+    pending = _make_pending(tmp_path, "VERSION_A")
+    target = pending.with_suffix("")
+
+    reject_pending_snapshot(pending)
+
+    assert not pending.exists()
+    assert not target.exists()
+
+
+def test_print_pending_diff_renders_insta_diff(tmp_path: Path, capfd) -> None:
+    # Commit a baseline, then create a changed pending snapshot.
+    accept_pending_snapshot(_make_pending(tmp_path, "VERSION_A"))
+    _write_project(tmp_path, "VERSION_B")
+    _run_pytest(tmp_path, "--snapshot-new")
+    pending = find_pending_snapshots(str(tmp_path))[0]
+
+    print_pending_diff(pending, str(tmp_path))
+
+    out = capfd.readouterr().out
+    # insta's own diff shows the removed old line and the added new line.
+    assert "-VERSION_A" in out or "VERSION_A" in out
+    assert "VERSION_B" in out
+
+
+def test_cli_review_accept(tmp_path: Path) -> None:
+    accept_pending_snapshot(_make_pending(tmp_path, "VERSION_A"))
+    _write_project(tmp_path, "VERSION_B")
+    _run_pytest(tmp_path, "--snapshot-new")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pysnaptest", "--root", str(tmp_path), "review"],
+        input="a\n",
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert find_pending_snapshots(str(tmp_path)) == []
+    committed = next((tmp_path / "snapshots").glob("*@pysnap.snap"))
+    assert "VERSION_B" in committed.read_text()
+
+
+def test_snapshot_update_flag_updates_in_place(tmp_path: Path) -> None:
+    # Establish a committed baseline.
+    pending = _make_pending(tmp_path, "VERSION_A")
+    accept_pending_snapshot(pending)
+
+    # Change the value and update in place with --snapshot-update, which passes.
+    _write_project(tmp_path, "VERSION_B")
+    result = _run_pytest(tmp_path, "--snapshot-update")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert find_pending_snapshots(str(tmp_path)) == []
+    committed = next((tmp_path / "snapshots").glob("*@pysnap.snap"))
+    assert "VERSION_B" in committed.read_text()


### PR DESCRIPTION
## What

Adds a **cargo-free snapshot review workflow**: a pytest plugin plus a small CLI so snapshots can be created, updated, and accepted without installing any Rust tooling. insta still does all the diffing and writing — the plugin only selects the update mode, and the CLI persists or discards pending files through insta's own `Snapshot::save`.

## Why

Until now, reviewing/updating snapshots required `cargo-insta`, i.e. a Rust toolchain. For a Python-first project that's a heavy prerequisite. This lets users stay entirely in the Python/pytest world.

## Changes

**pytest plugin** (registered via the `pytest11` entry point):
- `pytest --snapshot-update` — update snapshots in place and pass (`INSTA_UPDATE=always`)
- `pytest --snapshot-new` — record changed snapshots as pending `*.snap.new` files (`INSTA_UPDATE=new`)

**CLI** (`python -m pysnaptest`, also a `pysnaptest` console script):
- `review` — interactively review each pending snapshot, mirroring `cargo insta review` (shows insta's own diff, prompts accept / reject / skip / quit)
- `accept` — accept every pending snapshot
- `reject` — discard every pending snapshot
- `pending` — list pending snapshots with their diffs

**Rust helpers** (`src/lib.rs`): `accept_pending_snapshot`, `reject_pending_snapshot`, `print_pending_diff`. Diffs are rendered by insta's own `SnapshotPrinter`, so they match exactly what a failing assertion shows.

**Python API** (re-exported from `pysnaptest`): `find_pending_snapshots`, `accept_pending_snapshot`, `reject_pending_snapshot`, `accept_all`, `reject_all`, `review`.

**README**: documents the cargo-free workflow alongside the existing `cargo-insta` instructions.

## Example

```bash
pytest --snapshot-new          # record changed snapshots as pending files
python -m pysnaptest review     # interactively accept/reject each one
```

or in Python:

```python
from pysnaptest import find_pending_snapshots, accept_pending_snapshot

for pending in find_pending_snapshots():
    accept_pending_snapshot(pending)
```

The pending glob (`**/*@pysnap.snap.new`) is scoped to pysnaptest's own snapshots, so review never touches pending files produced by other tools.

## Testing

- `cargo clippy --all-features -- -D warnings` clean
- `cargo test` (6 passed)
- `pytest` (34 passed, 2 skipped) — includes a new `tests/test_review.py` covering the plugin, CLI, and helpers via real subprocess pytest runs
- Verified end-to-end that a fresh venv with only `pytest` + the built wheel (cargo/rustc/rustup/maturin/cargo-insta shadowed by failing stubs) can run the full record → review → accept roundtrip.
