### PR TITLE
Separate CLI review tooling from the assertion library

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ match exactly what you see from a failing assertion or `cargo insta review`.
 You can also drive this from Python:
 
 ```python
-from pysnaptest import find_pending_snapshots, accept_pending_snapshot
+from pysnaptest.review import find_pending_snapshots, accept_pending_snapshot
 
 for pending in find_pending_snapshots():
     accept_pending_snapshot(pending)

--- a/python/pysnaptest/__init__.py
+++ b/python/pysnaptest/__init__.py
@@ -1,7 +1,12 @@
 """Public API for :mod:`pysnaptest`.
 
-This module re-exports the most commonly used helpers so they can be imported
-directly from ``pysnaptest``.
+This module re-exports the most commonly used snapshot-assertion helpers so they
+can be imported directly from ``pysnaptest``.
+
+The cargo-free review workflow (accepting/rejecting pending snapshots) is kept
+separate from the assertion library. Import those helpers from
+:mod:`pysnaptest.review`, run the CLI with ``pysnaptest``, or enable the pytest
+plugin via ``pysnaptest.pytest_plugin``.
 """
 
 # ruff: noqa: F401
@@ -17,13 +22,4 @@ from .assertion import (
     extract_from_pytest_env,
 )
 from .mocks import mock_json_snapshot, patch_json_snapshot
-from .review import (
-    find_pending_snapshots,
-    accept_pending_snapshot,
-    reject_pending_snapshot,
-    print_pending_diff,
-    accept_all,
-    reject_all,
-    review,
-)
 from ._pysnaptest import PySnapshot

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from pysnaptest import (
+from pysnaptest.review import (
     accept_pending_snapshot,
     find_pending_snapshots,
     print_pending_diff,


### PR DESCRIPTION
## Separate CLI review tooling from the assertion library

Keeps the top-level `pysnaptest` public API focused on snapshot **assertions**
and moves the cargo-free **review workflow** cleanly behind its own namespace.

### What changed
- `pysnaptest/__init__.py` no longer re-exports the review helpers
  (`find_pending_snapshots`, `accept_pending_snapshot`,
  `reject_pending_snapshot`, `print_pending_diff`, `accept_all`, `reject_all`,
  `review`).
- Those helpers still live in `pysnaptest.review` and are reached via:
  - `from pysnaptest.review import ...` for programmatic use,
  - the `pysnaptest` CLI (`pysnaptest review/accept/reject/pending`),
  - the pytest plugin (`pysnaptest.pytest_plugin`).
- Updated `tests/test_review.py` and the README Python example to import from
  `pysnaptest.review`.

### Why
The assertion library and the review/CLI tooling are separate concerns. Keeping
review helpers out of the top-level namespace makes the library surface smaller
and the CLI/plugin the clear entry points for snapshot management.

### Breaking change
`from pysnaptest import find_pending_snapshots, accept_pending_snapshot, ...`
now fails. Import from `pysnaptest.review` instead.

### Validation
- `maturin develop` clean
- 34 passed, 2 skipped
- `ruff format --check` clean
- `pysnaptest --help` and `pysnaptest.review` imports verified
