### PR TITLE
Fix binary snapshot extension and async keyword-form decorator

### DIFF
--- a/python/pysnaptest/assertion.py
+++ b/python/pysnaptest/assertion.py
@@ -8,7 +8,7 @@ structures.
 from __future__ import annotations
 
 from typing import Callable, Any, Dict, overload, Union, Optional, TYPE_CHECKING
-from functools import partial, wraps
+from functools import wraps
 import asyncio
 
 from ._pysnaptest import (
@@ -356,14 +356,13 @@ def insta_snapshot(
         allow_duplicates: Whether to allow duplicate snapshot names.
     """
 
-    if isinstance(result, dict) or isinstance(result, list):
+    if isinstance(result, (dict, list)):
         assert_json_snapshot(result, snapshot_path, snapshot_name, redactions)
     elif isinstance(result, bytes):
         assert_binary_snapshot(
             result,
             snapshot_path,
             snapshot_name,
-            extension=dataframe_snapshot_format,
             allow_duplicates=allow_duplicates,
         )
     elif try_is_pandas_df(result) or try_is_polars_df(result):
@@ -425,10 +424,29 @@ def snapshot(  # noqa: F811
         Callable: The wrapped function.
     """
 
-    if asyncio.iscoroutinefunction(func):
+    def _wrap(target: Callable) -> Callable:
+        if not callable(target):
+            raise TypeError("Not a callable. Did you use a non-keyword argument?")
 
-        async def asserted_func(func: Callable, *args: Any, **kwargs: Any):
-            result = await func(*args, **kwargs)
+        if asyncio.iscoroutinefunction(target):
+
+            @wraps(target)
+            async def asserted_func(*args: Any, **kwargs: Any):
+                result = await target(*args, **kwargs)
+                insta_snapshot(
+                    result,
+                    snapshot_path=snapshot_path,
+                    snapshot_name=snapshot_name,
+                    redactions=redactions,
+                    dataframe_snapshot_format=dataframe_snapshot_format,
+                    allow_duplicates=allow_duplicates,
+                )
+
+            return asserted_func
+
+        @wraps(target)
+        def asserted_func(*args: Any, **kwargs: Any):
+            result = target(*args, **kwargs)
             insta_snapshot(
                 result,
                 snapshot_path=snapshot_path,
@@ -438,25 +456,9 @@ def snapshot(  # noqa: F811
                 allow_duplicates=allow_duplicates,
             )
 
-    else:
-
-        def asserted_func(func: Callable, *args: Any, **kwargs: Any):
-            result = func(*args, **kwargs)
-            insta_snapshot(
-                result,
-                snapshot_path=snapshot_path,
-                snapshot_name=snapshot_name,
-                redactions=redactions,
-                dataframe_snapshot_format=dataframe_snapshot_format,
-                allow_duplicates=allow_duplicates,
-            )
+        return asserted_func
 
     if func is not None:
-        if not callable(func):
-            raise TypeError("Not a callable. Did you use a non-keyword argument?")
-        return wraps(func)(partial(asserted_func, func))
+        return _wrap(func)
 
-    def decorator(func: Callable) -> Callable:
-        return wraps(func)(partial(asserted_func, func))
-
-    return decorator
+    return _wrap

--- a/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_async_parameterized@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_async_parameterized@pysnap.snap
@@ -1,0 +1,5 @@
+---
+source: src/lib.rs
+description: "Test File Path: tests/test_snapshots.py"
+---
+6

--- a/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_bytes_uses_bin_extension@pysnap.snap
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_bytes_uses_bin_extension@pysnap.snap
@@ -1,0 +1,6 @@
+---
+source: src/lib.rs
+description: "Test File Path: tests/test_snapshots.py"
+extension: bin
+snapshot_kind: binary
+---

--- a/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_bytes_uses_bin_extension@pysnap.snap.bin
+++ b/tests/snapshots/pysnaptest__test_snapshots_test_snapshot_bytes_uses_bin_extension@pysnap.snap.bin
@@ -1,0 +1,1 @@
+raw bytes result

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -174,6 +174,17 @@ async def test_snapshot_async() -> int:
     return 5
 
 
+@pytest.mark.asyncio
+@snapshot()
+async def test_snapshot_async_parameterized() -> int:
+    return 6
+
+
+@snapshot
+def test_snapshot_bytes_uses_bin_extension() -> bytes:
+    return b"raw bytes result"
+
+
 def test_assert_snapshot_multiple():
     snapshot_name_prefix = "test_snapshots_test_assert_snapshot_multiple"
     assert_json_snapshot("expected_result_1", snapshot_name=f"{snapshot_name_prefix}_1")


### PR DESCRIPTION
## Summary

Two correctness fixes in the snapshot decorator/dispatch path.

### 1. Binary snapshots got a `.csv` extension
`insta_snapshot()` passed `extension=dataframe_snapshot_format` (default `"csv"`) when snapshotting raw `bytes`, so `@snapshot` on a `bytes`-returning function wrote a binary payload with a `.csv` extension. It now lets `assert_binary_snapshot` use its own `"bin"` default.

### 2. Keyword-form `@snapshot(...)` never awaited coroutines
`snapshot()` evaluated `asyncio.iscoroutinefunction(func)` at decoration time. In the keyword form (`@snapshot(snapshot_name=...)`) `func` is `None`, so the async branch was never taken and the coroutine was never awaited. The wrapper is now resolved against the actual target inside the decorator, so both the bare and parameterized forms support async functions.

## Tests
- New async `@snapshot()` (keyword form) regression test — snapshot records the awaited value, not a coroutine repr.
- New `bytes` `@snapshot` test asserting the `.bin` extension is produced.

Full suite: 36 passed, 2 skipped.
