### PR TITLE
Add py.typed marker and type stubs for the extension module

### DIFF
--- a/python/pysnaptest/_pysnaptest.pyi
+++ b/python/pysnaptest/_pysnaptest.pyi
@@ -1,0 +1,108 @@
+"""Type stubs for the compiled ``pysnaptest._pysnaptest`` extension module.
+
+These declarations mirror the pyo3 bindings defined in ``src/`` so that editors
+and type checkers can offer completion and validation for the Rust-backed API.
+"""
+
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+_StrPath = Union[str, os.PathLike[str]]
+_Redactions = dict[str, Union[str, int, None]]
+
+class SnapshotInfo:
+    """Snapshot configuration resolved from the active pytest test."""
+
+    @staticmethod
+    def from_pytest(
+        snapshot_path_override: Optional[_StrPath] = ...,
+        snapshot_name_override: Optional[str] = ...,
+        allow_duplicates: bool = ...,
+    ) -> "SnapshotInfo":
+        """Build snapshot info from the ``PYTEST_CURRENT_TEST`` environment."""
+        ...
+
+    def snapshot_folder(self) -> Path:
+        """Return the directory snapshots are stored in."""
+        ...
+
+    def last_snapshot_name(self) -> str:
+        """Return the name of the most recently used snapshot."""
+        ...
+
+    def next_snapshot_name(self) -> str:
+        """Return the name the next snapshot assertion will use."""
+        ...
+
+    def last_snapshot_path(self, module_path: Optional[str]) -> Path:
+        """Return the path of the most recently used snapshot."""
+        ...
+
+    def next_snapshot_path(self, module_path: Optional[str]) -> Path:
+        """Return the path the next snapshot assertion will write."""
+        ...
+
+class PySnapshot:
+    """A snapshot loaded from disk via insta."""
+
+    @staticmethod
+    def from_file(p: _StrPath) -> "PySnapshot":
+        """Load a snapshot from ``p``."""
+        ...
+
+    def contents(self) -> bytes:
+        """Return the snapshot contents as raw bytes."""
+        ...
+
+def assert_json_snapshot(
+    test_info: SnapshotInfo,
+    result: Any,
+    redactions: Optional[_Redactions] = ...,
+) -> None:
+    """Assert that ``result`` matches its stored JSON snapshot."""
+    ...
+
+def assert_csv_snapshot(
+    test_info: SnapshotInfo,
+    result: Any,
+    redactions: Optional[_Redactions] = ...,
+) -> None:
+    """Assert that CSV text matches its stored snapshot."""
+    ...
+
+def assert_binary_snapshot(
+    test_info: SnapshotInfo,
+    extension: str,
+    result: bytes,
+) -> None:
+    """Assert that binary data matches its stored snapshot."""
+    ...
+
+def assert_snapshot(test_info: SnapshotInfo, result: Any) -> None:
+    """Assert that a value matches its stored text snapshot."""
+    ...
+
+def mock_json_snapshot(
+    py_fn: Callable[..., Any],
+    snapshot_info: SnapshotInfo,
+    record: bool,
+    redactions: Optional[_Redactions],
+) -> Callable[..., Any]:
+    """Return a callable that snapshots ``py_fn``'s JSON result."""
+    ...
+
+def accept_pending_snapshot(pending_path: _StrPath) -> Path:
+    """Accept a pending snapshot, persisting it to its ``.snap`` file."""
+    ...
+
+def reject_pending_snapshot(pending_path: _StrPath) -> None:
+    """Reject a pending snapshot, deleting its ``.snap.new`` file."""
+    ...
+
+def print_pending_diff(
+    pending_path: _StrPath,
+    workspace_root: Optional[_StrPath] = ...,
+) -> None:
+    """Print insta's own diff for a pending snapshot against its target."""
+    ...


### PR DESCRIPTION
## Summary

`pysnaptest`'s pure-Python layer is fully annotated, but the Rust-backed `_pysnaptest` extension shipped **without stubs** and the package was **not marked as typed** (no `py.typed`). As a result, downstream users got no editor completion or type checking for the re-exported symbols (`PySnapshot`, `SnapshotInfo`, and the underlying `assert_*` / `mock_json_snapshot` / pending-snapshot helpers).

## Changes

- **`python/pysnaptest/py.typed`** — PEP 561 marker so type checkers treat the package as typed.
- **`python/pysnaptest/_pysnaptest.pyi`** — hand-written stub mirroring the pyo3 bindings in `src/`, covering:
  - functions: `assert_json_snapshot`, `assert_csv_snapshot`, `assert_binary_snapshot`, `assert_snapshot`, `mock_json_snapshot`, `accept_pending_snapshot`, `reject_pending_snapshot`, `print_pending_diff`
  - classes: `SnapshotInfo` (+ `from_pytest`, `snapshot_folder`, `last/next_snapshot_name`, `last/next_snapshot_path`) and `PySnapshot` (+ `from_file`, `contents`)

## Verification

- The stub's declared surface was diffed against the compiled module — **exact parity** for top-level functions and both classes' methods (no runtime-only or stub-only names).
- Pylance now resolves the re-exported helpers to their typed signatures (e.g. hovering `assert_csv_snapshot` shows `(test_info: SnapshotInfo, result: Any, redactions: _Redactions | None = ...) -> None`).
- maturin ships both files via the existing `python-source = "python"` layout.
- `ruff format --check` clean; full suite: 34 passed, 2 skipped.
