### PR TITLE
Normalize typing to classic typing forms and make exports explicit

### DIFF
--- a/python/pysnaptest/__init__.py
+++ b/python/pysnaptest/__init__.py
@@ -9,7 +9,6 @@ separate from the assertion library. Import those helpers from
 plugin via ``pysnaptest.pytest_plugin``.
 """
 
-# ruff: noqa: F401
 from .assertion import (
     snapshot,
     assert_json_snapshot,
@@ -23,3 +22,18 @@ from .assertion import (
 )
 from .mocks import mock_json_snapshot, patch_json_snapshot
 from ._pysnaptest import PySnapshot
+
+__all__ = [
+    "snapshot",
+    "assert_json_snapshot",
+    "assert_csv_snapshot",
+    "assert_snapshot",
+    "assert_dataframe_snapshot",
+    "assert_binary_snapshot",
+    "sorted_redaction",
+    "rounded_redaction",
+    "extract_from_pytest_env",
+    "mock_json_snapshot",
+    "patch_json_snapshot",
+    "PySnapshot",
+]

--- a/python/pysnaptest/assertion.py
+++ b/python/pysnaptest/assertion.py
@@ -7,7 +7,7 @@ structures.
 
 from __future__ import annotations
 
-from typing import Callable, Any, Dict, overload, Union, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union, overload
 from functools import wraps
 import asyncio
 
@@ -74,9 +74,9 @@ def assert_json_snapshot(
     result: Any,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     allow_duplicates: bool = False,
-):
+) -> None:
     """Assert that a value matches a stored JSON snapshot.
 
     Args:
@@ -95,9 +95,9 @@ def assert_csv_snapshot(
     result: Any,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     allow_duplicates: bool = False,
-):
+) -> None:
     """Assert that CSV text matches the stored snapshot.
 
     Args:
@@ -152,12 +152,12 @@ def assert_pandas_dataframe_snapshot(
     df: pd.DataFrame,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
     *args,
     **kwargs,
-):
+) -> None:
     """Snapshot assertion for pandas DataFrames.
 
     Args:
@@ -200,12 +200,12 @@ def assert_polars_dataframe_snapshot(
     df: pl.DataFrame,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
     *args,
     **kwargs,
-):
+) -> None:
     """Snapshot assertion for polars DataFrames.
 
     Args:
@@ -248,12 +248,12 @@ def assert_dataframe_snapshot(
     df: Union[pd.DataFrame, pl.DataFrame],
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
     *args,
     **kwargs,
-):
+) -> None:
     """Snapshot assertion for either pandas or polars ``DataFrame`` objects.
 
     Args:
@@ -298,11 +298,11 @@ def assert_dataframe_snapshot(
 
 def assert_binary_snapshot(
     result: bytes,
-    snapshot_path: str | None = None,
-    snapshot_name: str | None = None,
+    snapshot_path: Optional[str] = None,
+    snapshot_name: Optional[str] = None,
     extension: str = "bin",
     allow_duplicates: bool = False,
-):
+) -> None:
     """Assert that binary data matches the stored snapshot.
 
     Args:
@@ -319,10 +319,10 @@ def assert_binary_snapshot(
 
 def assert_snapshot(
     result: Any,
-    snapshot_path: str | None = None,
-    snapshot_name: str | None = None,
+    snapshot_path: Optional[str] = None,
+    snapshot_name: Optional[str] = None,
     allow_duplicates: bool = False,
-):
+) -> None:
     """Assert that a string matches the stored snapshot.
 
     Args:
@@ -340,10 +340,10 @@ def insta_snapshot(
     result: Any,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
-):
+) -> None:
     """Dispatch a value to the appropriate snapshot assertion.
 
     Args:
@@ -394,7 +394,7 @@ def snapshot(
     *,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
 ) -> Callable:  # noqa: F811
@@ -406,7 +406,7 @@ def snapshot(  # noqa: F811
     *,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
 ) -> Callable:

--- a/python/pysnaptest/mocks.py
+++ b/python/pysnaptest/mocks.py
@@ -6,12 +6,12 @@ are automatically snapshot tested.
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Union
 import importlib
 from unittest.mock import patch
 import functools
 
-from ._pysnaptest import mock_json_snapshot as _mock_json_snapshot, SnapshotInfo
+from ._pysnaptest import mock_json_snapshot as _mock_json_snapshot
 from .assertion import extract_from_pytest_env
 
 
@@ -20,7 +20,7 @@ def mock_json_snapshot(
     record: bool = False,
     snapshot_path: Optional[str] = None,
     snapshot_name: Optional[str] = None,
-    redactions: Optional[Dict[str, str | int | None]] = None,
+    redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     allow_duplicates: bool = False,
 ):
     """Return a function mock that snapshots its JSON result.
@@ -69,7 +69,7 @@ class patch_json_snapshot:
         record: bool = False,
         snapshot_path: Optional[str] = None,
         snapshot_name: Optional[str] = None,
-        redactions: Optional[Dict[str, str | int | None]] = None,
+        redactions: Optional[Dict[str, Union[str, int, None]]] = None,
         allow_duplicates: bool = False,
     ):
         """Create the patch configuration.


### PR DESCRIPTION
## Summary

The assertion library mixed typing dialects — e.g. `Optional[Dict[str, str | int | None]]` combined `typing` generics with PEP 604 `|` unions, and a couple of helpers used `str | None` directly. This standardizes on the classic `typing` forms and makes the public export surface explicit.

## Why classic `typing` (no `|`)

Both modules use `from __future__ import annotations`, so `|` doesn't break at import time. **But** a bare `str | int` still raises `TypeError` under `typing.get_type_hints()` on Python < 3.10. Since `requires-python >= 3.9`, avoiding the `|` operator keeps the library introspectable on the full supported range. Verified: `get_type_hints()` now resolves every annotated callable (the pandas/polars forward refs are `TYPE_CHECKING`-only and behave identically on all versions).

## Changes

- Convert all annotations in `assertion.py` and `mocks.py` to `Optional` / `Union` / `Dict` — no `|` union operator anywhere.
- Add the `-> None` return annotations several `assert_*` helpers were missing.
- Add `__all__` to `__init__.py` (identical set of names) and drop the blanket `# ruff: noqa: F401`.
- Remove a pre-existing unused `SnapshotInfo` import in `mocks.py`.

No behavior change. `ruff check` / `ruff format --check` clean; full suite: 34 passed, 2 skipped.
