### PR TITLE
Add obsolete-snapshot detection (pysnaptest unused)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ capabilities that peers don't offer out of the box:
   become deterministic without hand-written fixtures.
 - **Insta redaction selectors** for scrubbing nondeterministic fields (ids,
   timestamps) before comparison.
+- **Obsolete-snapshot detection.** Helpers to find `.snap` files that no test
+  references any more, so snapshot directories don't rot as tests change.
 
 It also keeps the basics other tools give you:
 
@@ -129,11 +131,8 @@ assert_json_snapshot(
 )
 ```
 
-> **Note:** This is a behavior change from earlier versions, where objects that
-> weren't native `dict`/`list`/`bytes`/`DataFrame` values were snapshotted using
-> their string representation. Such objects are now serialized to JSON. Pass a
-> `DataFrame` to `assert_dataframe_snapshot` — `assert_json_snapshot` raises a
-> `TypeError` for DataFrames.
+Pass a `DataFrame` to `assert_dataframe_snapshot`; `assert_json_snapshot` raises
+a `TypeError` for DataFrames.
 
 ### Which API do I use?
 
@@ -154,9 +153,10 @@ test is shaped:
 
 ## Updating Snapshots
 
-If the output changes intentionally, you can review and update snapshots in two
-ways: with the built-in, cargo-free workflow (recommended for Python projects)
-or with `cargo-insta review`.
+If the output changes intentionally, you can review and update snapshots with the
+built-in, cargo-free workflow (recommended for Python projects). If you already
+use Rust tooling, `cargo-insta` also works — see [Reviewing with
+`cargo-insta`](#reviewing-with-cargo-insta).
 
 ### Reviewing without cargo (recommended)
 
@@ -172,8 +172,8 @@ pytest --snapshot-update
 ```
 
 Prefer to inspect changes and accept them yourself? Record pending `*.snap.new`
-files instead, then review them the way `cargo insta review` does — one snapshot
-at a time, showing insta's own diff and prompting to accept, reject, or skip:
+files instead, then review them one snapshot at a time, showing insta's own diff
+and prompting to accept, reject, or skip:
 
 ```bash
 pytest --snapshot-new          # record changed snapshots as pending files
@@ -189,7 +189,7 @@ pysnaptest reject              # discard every pending snapshot
 ```
 
 The diffs shown by `review` and `pending` are rendered by insta itself, so they
-match exactly what you see from a failing assertion or `cargo insta review`.
+match exactly what you see from a failing assertion.
 
 You can also drive this from Python:
 
@@ -228,6 +228,29 @@ tests so both the library and `cargo-insta` know where snapshots are stored. In
 the example project the tests are inside a `tests` folder, so `pytest.ini` sets
 `INSTA_WORKSPACE_ROOT=tests`, allowing the CLI to find
 `examples/my_project/tests/snapshots`.
+
+## Detecting obsolete snapshots
+
+As tests are renamed or removed, their `.snap` files are left behind. The
+`pysnaptest unused` command runs your test suite once and reports the committed
+snapshots that no test referenced:
+
+```bash
+pysnaptest unused              # run the suite and list unreferenced snapshots
+pysnaptest unused --delete     # ...and delete them (plus any binary sidecars)
+```
+
+Because the whole suite runs, a snapshot is flagged only when its owning test
+module still exists. Pass extra pytest arguments after `--`:
+
+```bash
+pysnaptest unused --delete -- -k integration
+```
+
+Without `--delete`, the command exits non-zero when it finds unreferenced
+snapshots, so it can gate CI. The `pysnaptest.unused` module exposes the same
+building blocks (`find_unused_snapshots`, `delete_snapshot`, ...) if you want to
+script it directly.
 
 
 ## Examples

--- a/python/pysnaptest/__main__.py
+++ b/python/pysnaptest/__main__.py
@@ -2,7 +2,7 @@
 
 Run ``pysnaptest --help`` for usage. Mirrors the common
 ``cargo insta`` subcommands (``review``, ``accept``, ``reject``,
-``pending-snapshots``) but works without any Rust tooling.
+``pending-snapshots``, ``unused``) but works without any Rust tooling.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from .review import (
     reject_all,
     review,
 )
+from .unused import delete_snapshot, unused_snapshots
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -37,6 +38,21 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("accept", help="Accept all pending snapshots.")
     sub.add_parser("reject", help="Reject all pending snapshots.")
     sub.add_parser("pending", help="List pending snapshots and their diffs.")
+    unused = sub.add_parser(
+        "unused",
+        help="Run the test suite and report snapshots no test referenced.",
+    )
+    unused.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete the unreferenced snapshots (and any binary sidecars).",
+    )
+    unused.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded to pytest (e.g. a test path). "
+        "Prefix with -- to separate them from pysnaptest options.",
+    )
 
     return parser
 
@@ -65,9 +81,43 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             print(f"\n{path}")
             print_pending_diff(path, args.root)
         print(f"\n{len(pending)} pending snapshot(s).")
+    elif args.command == "unused":
+        return _unused_command(args)
     else:  # "review" or no subcommand
         review(args.root)
     return 0
+
+
+def _unused_command(args: argparse.Namespace) -> int:
+    """Handle ``pysnaptest unused``: run the suite, then report or delete.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        int: ``0`` when nothing was left unreferenced, ``1`` otherwise so the
+        command can gate CI when run without ``--delete``.
+    """
+
+    pytest_args = [a for a in args.pytest_args if a != "--"]
+    unused = unused_snapshots(args.root, pytest_args)
+
+    if not unused:
+        print("No unused snapshots found.")
+        return 0
+
+    if args.delete:
+        print(f"Deleting {len(unused)} unused snapshot(s):")
+        for path in unused:
+            delete_snapshot(path)
+            print(f"  {path}")
+        return 0
+
+    print(f"Found {len(unused)} unused snapshot(s):")
+    for path in unused:
+        print(f"  {path}")
+    print("Re-run with `pysnaptest unused --delete` to remove them.")
+    return 1
 
 
 if __name__ == "__main__":

--- a/python/pysnaptest/review.py
+++ b/python/pysnaptest/review.py
@@ -19,11 +19,18 @@ from ._pysnaptest import (
     accept_pending_snapshot as _accept_pending_snapshot,
     reject_pending_snapshot as _reject_pending_snapshot,
     print_pending_diff as _print_pending_diff,
+    SNAPSHOT_SUFFIX,
 )
+
+#: Glob that matches only pysnaptest's own committed snapshots. ``SNAPSHOT_SUFFIX``
+#: (``@pysnap.snap``) is defined once in Rust (``src/common.rs``) and exported by
+#: the compiled ``_pysnaptest`` module, so ``review`` and ``unused`` always agree
+#: with the snapshot files insta actually writes.
+SNAPSHOT_GLOB = f"**/*{SNAPSHOT_SUFFIX}"
 
 #: Glob that matches only pysnaptest's own pending snapshots, so review never
 #: touches pending files produced by other snapshot tools.
-PENDING_GLOB = "**/*@pysnap.snap.new"
+PENDING_GLOB = f"{SNAPSHOT_GLOB}.new"
 
 
 def _root(root: Optional[str]) -> Path:

--- a/python/pysnaptest/unused.py
+++ b/python/pysnaptest/unused.py
@@ -1,0 +1,277 @@
+"""Detect snapshot files that no test referenced ("obsolete" snapshots).
+
+This leans on insta's own machinery. When the ``INSTA_SNAPSHOT_REFERENCES_FILE``
+environment variable is set, insta appends the path of every snapshot file it
+touches during an assertion to that file -- this is exactly the mechanism
+``cargo insta test --unreferenced`` uses. The ``pysnaptest unused`` CLI command
+points that variable at a temp file, runs your test suite once, and then treats
+anything on disk that isn't listed as a candidate for deletion.
+
+Mock *replay* is covered too: :func:`pysnaptest.mocks.mock_json_snapshot` reads
+a recorded response snapshot without going through an insta assertion, so the
+Rust ``read_json_snapshot`` primitive appends that path to the same reference
+file (just as insta's own ``memoize_snapshot_file`` does), keeping the
+referenced set complete.
+
+Because the CLI runs the whole suite, every test file runs, so scoping is simple:
+a snapshot is reported only when its owning test file still exists next to the
+snapshot directory (:func:`find_unused_snapshots` takes the set of stems that
+ran, which the CLI fills with every discovered test module).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+
+from ._pysnaptest import delete_snapshot as _delete_snapshot
+from .review import SNAPSHOT_GLOB, SNAPSHOT_SUFFIX, _root
+
+#: Splits a snapshot filename into its Rust module prefix and the remainder,
+#: which starts with the owning test file's stem: ``<stem>_<test_name>...``.
+_NAME_RE = re.compile(
+    rf"^(?P<module>.+?)__(?P<remainder>.+){re.escape(SNAPSHOT_SUFFIX)}$"
+)
+
+
+def read_referenced(reference_file: str | Path) -> Set[Path]:
+    """Read the set of referenced snapshot paths insta recorded.
+
+    Args:
+        reference_file: Path insta appended referenced snapshots to (one per
+            line). A missing file yields an empty set.
+
+    Returns:
+        Set[Path]: Resolved paths of every referenced snapshot.
+    """
+
+    referenced: Set[Path] = set()
+    try:
+        with open(reference_file, encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped:
+                    referenced.add(Path(stripped).resolve())
+    except FileNotFoundError:
+        pass
+    return referenced
+
+
+def discover_snapshot_dirs(root: str | Path) -> List[Path]:
+    """Find every ``snapshots`` directory under ``root``.
+
+    Args:
+        root: Directory to search recursively.
+
+    Returns:
+        List[Path]: Sorted ``snapshots`` directories.
+    """
+
+    return sorted(p for p in Path(root).rglob("snapshots") if p.is_dir())
+
+
+def snapshot_files(directories: Iterable[Path]) -> Set[Path]:
+    """Return every committed pysnaptest snapshot under ``directories``.
+
+    Args:
+        directories: Snapshot directories to scan (typically ``<testdir>/snapshots``).
+
+    Returns:
+        Set[Path]: Resolved paths to ``*@pysnap.snap`` metadata files.
+    """
+
+    found: Set[Path] = set()
+    for directory in directories:
+        if not directory.is_dir():
+            continue
+        for path in directory.glob(SNAPSHOT_GLOB):
+            if path.is_file():
+                found.add(path.resolve())
+    return found
+
+
+def owning_stem(snapshot_path: Path, known_stems: Iterable[str]) -> Optional[str]:
+    """Resolve which test-file stem owns ``snapshot_path``.
+
+    A snapshot filename looks like ``<module>__<stem>_<test_name>...@pysnap.snap``.
+    Because both ``<stem>`` and ``<test_name>`` may contain underscores, the stem
+    is ambiguous in isolation; it is resolved by matching against the set of
+    ``known_stems`` (the test modules that exist next to the snapshot directory)
+    and preferring the longest stem that fits on an underscore boundary. That way
+    ``test`` never steals ``test_snapshots``'s files.
+
+    Args:
+        snapshot_path: Path to a ``*@pysnap.snap`` file.
+        known_stems: Candidate test-file stems (e.g. ``{"test_main", "test_api"}``).
+
+    Returns:
+        Optional[str]: The owning stem, or ``None`` if no known stem matches.
+    """
+
+    match = _NAME_RE.match(snapshot_path.name)
+    if match is None:
+        return None
+    remainder = match.group("remainder")
+
+    best: Optional[str] = None
+    for stem in known_stems:
+        if remainder == stem or remainder.startswith(f"{stem}_"):
+            if best is None or len(stem) > len(best):
+                best = stem
+    return best
+
+
+def sibling_test_stems(directory: Path) -> Set[str]:
+    """Return the stems of test modules living next to a ``snapshots`` directory.
+
+    Snapshots are stored in ``<testdir>/snapshots``; the test modules that own
+    them are the ``.py`` files directly in ``<testdir>``. Knowing every stem that
+    exists there (not just the ones that ran) is what lets :func:`owning_stem`
+    disambiguate overlapping names.
+
+    Args:
+        directory: A ``snapshots`` directory.
+
+    Returns:
+        Set[str]: Stems of sibling ``.py`` files.
+    """
+
+    parent = directory.parent
+    if not parent.is_dir():
+        return set()
+    return {p.stem for p in parent.glob("*.py")}
+
+
+def find_unused_snapshots(
+    referenced: Iterable[Path],
+    snapshot_dirs: Iterable[Path],
+    ran_stems: Iterable[str],
+) -> List[Path]:
+    """Return committed snapshots that ran-tests own but never referenced.
+
+    A snapshot is reported only when its owning test file both exists next to the
+    snapshot directory and is among ``ran_stems``. Snapshots owned by stems that
+    did not run (or whose test file is gone) are left alone, so partial test runs
+    do not produce false positives.
+
+    Args:
+        referenced: Snapshot metadata paths insta recorded as referenced.
+        snapshot_dirs: The ``snapshots`` directories to scan.
+        ran_stems: Test-file stems that actually ran this session.
+
+    Returns:
+        List[Path]: Sorted, resolved paths to unused snapshot metadata files.
+    """
+
+    referenced_resolved = {Path(p).resolve() for p in referenced}
+    ran = set(ran_stems)
+    dirs = list(snapshot_dirs)
+
+    stems_by_dir: Dict[Path, Set[str]] = {d: sibling_test_stems(d) for d in dirs}
+
+    unused: List[Path] = []
+    for path in snapshot_files(dirs):
+        if path in referenced_resolved:
+            continue
+        known = stems_by_dir.get(path.parent, set()) or sibling_test_stems(path.parent)
+        stem = owning_stem(path, known)
+        if stem is not None and stem in ran:
+            unused.append(path)
+    return sorted(unused)
+
+
+def delete_snapshot(snapshot_path: Path) -> List[Path]:
+    """Delete a snapshot metadata file and its binary sidecar (if any).
+
+    Deletion is delegated to the Rust ``delete_snapshot`` primitive, which
+    resolves any binary sidecar through insta's own ``build_binary_path`` (the
+    same code path that cleans up pending files), so only the data file insta
+    actually wrote is removed.
+
+    Args:
+        snapshot_path: Path to a ``*@pysnap.snap`` metadata file.
+
+    Returns:
+        List[Path]: The files that were removed.
+    """
+
+    return [Path(p) for p in _delete_snapshot(str(snapshot_path))]
+
+
+def collect_references(
+    reference_file: Path,
+    pytest_args: Sequence[str],
+    root: Path,
+) -> int:
+    """Run the test suite once, recording every referenced snapshot.
+
+    Points insta's ``INSTA_SNAPSHOT_REFERENCES_FILE`` at ``reference_file`` and
+    runs ``python -m pytest`` (plus any ``pytest_args``) as a subprocess, so
+    insta appends every snapshot it touches. Mirrors what ``cargo insta test``
+    does before checking for unreferenced snapshots.
+
+    Args:
+        reference_file: File insta should append referenced snapshots to.
+        pytest_args: Extra arguments forwarded to pytest (e.g. a test path).
+        root: Working directory to run pytest in.
+
+    Returns:
+        int: pytest's exit code.
+    """
+
+    env = dict(os.environ)
+    env["INSTA_SNAPSHOT_REFERENCES_FILE"] = str(reference_file)
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", *pytest_args],
+        cwd=str(root),
+        env=env,
+    )
+    return completed.returncode
+
+
+def unused_snapshots(
+    root: Optional[str] = None, pytest_args: Sequence[str] = ()
+) -> List[Path]:
+    """Return snapshots no test referenced after running the suite under ``root``.
+
+    Runs the test suite once (via :func:`collect_references`) to learn which
+    snapshots are referenced, then diffs that against the snapshots on disk.
+    Because the whole suite runs, every test file counts as "ran", so a snapshot
+    is reported whenever its owning test module still exists.
+
+    Args:
+        root: Project directory to run pytest in and scan for ``snapshots`` dirs.
+            Defaults to ``$INSTA_WORKSPACE_ROOT`` or the current directory, matching
+            the other ``pysnaptest`` subcommands.
+        pytest_args: Extra arguments forwarded to pytest.
+
+    Returns:
+        List[Path]: Sorted paths to unreferenced snapshot metadata files.
+    """
+
+    root_path = _root(root)
+    snapshot_dirs = discover_snapshot_dirs(root_path)
+    ran_stems: Set[str] = set()
+    for directory in snapshot_dirs:
+        ran_stems |= sibling_test_stems(directory)
+
+    handle = tempfile.NamedTemporaryFile(
+        prefix="pysnaptest-refs-", suffix=".txt", delete=False
+    )
+    handle.close()
+    reference_file = Path(handle.name)
+    try:
+        collect_references(reference_file, pytest_args, root_path)
+        referenced = read_referenced(reference_file)
+    finally:
+        try:
+            reference_file.unlink()
+        except OSError:
+            pass
+
+    return find_unused_snapshots(referenced, snapshot_dirs, ran_stems)

--- a/src/common.rs
+++ b/src/common.rs
@@ -18,6 +18,13 @@ use pyo3::types::PyAnyMethods;
 
 const PYSNAPSHOT_SUFFIX: &str = "pysnap";
 
+/// Filename tail of every committed pysnaptest snapshot, e.g.
+/// `foo@pysnap.snap`. insta composes snapshot files as `<name>@<suffix>.snap`,
+/// so this is `@{PYSNAPSHOT_SUFFIX}.snap`. Exposed to Python
+/// (`pysnaptest._pysnaptest.SNAPSHOT_SUFFIX`) so `review`/`unused` derive their
+/// globs from the same source of truth.
+pub const SNAPSHOT_FILE_SUFFIX: &str = "@pysnap.snap";
+
 static TEST_NAME_COUNTERS: Lazy<Mutex<BTreeMap<String, usize>>> =
     Lazy::new(|| Mutex::new(BTreeMap::new()));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,17 +126,27 @@ pub fn assert_snapshot(test_info: &SnapshotInfo, result: &Bound<'_, PyAny>) -> P
     })
 }
 
-/// Removes a pending `.snap.new` file and, for binary snapshots, its sidecar data file.
-fn remove_pending_files(pending_path: &Path, snapshot: &Snapshot) -> PyResult<()> {
-    if let Some(binary_sidecar) = snapshot.build_binary_path(pending_path) {
-        if binary_sidecar.exists() {
-            std::fs::remove_file(&binary_sidecar).map_err(|e| {
-                PyValueError::new_err(format!(
-                    "Unable to remove pending binary sidecar {binary_sidecar:?}: {e}"
-                ))
+/// Removes a snapshot's binary sidecar data file, if it has one.
+///
+/// The sidecar path is resolved through insta's own [`Snapshot::build_binary_path`]
+/// so we only ever touch the data file insta actually wrote (e.g. `@pysnap.snap.parquet`)
+/// and never an unrelated sibling such as a `.snap.new` pending file. Returns the
+/// removed sidecar path, or `None` when the snapshot is text-only or has no sidecar.
+fn remove_binary_sidecar(path: &Path, snapshot: &Snapshot) -> PyResult<Option<PathBuf>> {
+    if let Some(sidecar) = snapshot.build_binary_path(path) {
+        if sidecar.exists() {
+            std::fs::remove_file(&sidecar).map_err(|e| {
+                PyValueError::new_err(format!("Unable to remove binary sidecar {sidecar:?}: {e}"))
             })?;
+            return Ok(Some(sidecar));
         }
     }
+    Ok(None)
+}
+
+/// Removes a pending `.snap.new` file and, for binary snapshots, its sidecar data file.
+fn remove_pending_files(pending_path: &Path, snapshot: &Snapshot) -> PyResult<()> {
+    remove_binary_sidecar(pending_path, snapshot)?;
     std::fs::remove_file(pending_path).map_err(|e| {
         PyValueError::new_err(format!(
             "Unable to remove pending snapshot {pending_path:?}: {e}"
@@ -191,6 +201,29 @@ pub fn reject_pending_snapshot(pending_path: PathBuf) -> PyResult<()> {
             ))
         }),
     }
+}
+
+/// Deletes a committed snapshot file and its binary sidecar data file (if any).
+///
+/// The sidecar is resolved through insta's own [`Snapshot::build_binary_path`],
+/// the same primitive used to clean up pending files, so obsolete-snapshot
+/// deletion (`pysnaptest unused --delete`) removes exactly what insta wrote and
+/// never an unrelated sibling such as a `.snap.new` pending file. Returns the
+/// removed paths (the sidecar first, when present, then the metadata file). A
+/// corrupt/unreadable metadata file is still removed.
+#[pyfunction]
+pub fn delete_snapshot(snapshot_path: PathBuf) -> PyResult<Vec<PathBuf>> {
+    let mut removed = Vec::new();
+    if let Ok(snapshot) = Snapshot::from_file(&snapshot_path) {
+        if let Some(sidecar) = remove_binary_sidecar(&snapshot_path, &snapshot)? {
+            removed.push(sidecar);
+        }
+    }
+    std::fs::remove_file(&snapshot_path).map_err(|e| {
+        PyValueError::new_err(format!("Unable to remove snapshot {snapshot_path:?}: {e}"))
+    })?;
+    removed.push(snapshot_path);
+    Ok(removed)
 }
 
 /// Prints insta's own diff for a pending snapshot against its committed target.
@@ -293,7 +326,7 @@ impl SnapshotInfo {
             .unwrap_or(module_path!().to_string())
             .replace("::", "__");
         Ok(self.snapshot_folder.join(format!(
-            "{module_path}__{}@pysnap.snap",
+            "{module_path}__{}{SNAPSHOT_FILE_SUFFIX}",
             self.last_snapshot_name()
         )))
     }
@@ -303,7 +336,7 @@ impl SnapshotInfo {
             .unwrap_or(module_path!().to_string())
             .replace("::", "__");
         Ok(self.snapshot_folder.join(format!(
-            "{module_path}__{}@pysnap.snap",
+            "{module_path}__{}{SNAPSHOT_FILE_SUFFIX}",
             self.next_snapshot_name()
         )))
     }
@@ -314,6 +347,7 @@ impl SnapshotInfo {
 fn pysnaptest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SnapshotInfo>()?;
 
+    m.add("SNAPSHOT_SUFFIX", SNAPSHOT_FILE_SUFFIX)?;
     m.add_function(wrap_pyfunction!(assert_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_binary_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_json_snapshot, m)?)?;
@@ -323,6 +357,7 @@ fn pysnaptest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_json_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(accept_pending_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(reject_pending_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(delete_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(print_pending_diff, m)?)?;
     m.add_class::<PySnapshot>()?;
     Ok(())

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -26,7 +26,8 @@
 //! call site) is preserved.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use insta::internals::SnapshotContents;
 use insta::Snapshot;
@@ -34,6 +35,25 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::{RedactionType, SnapshotInfo};
+
+/// Records `snapshot_path` as referenced, mirroring insta's own
+/// `memoize_snapshot_file`: when `INSTA_SNAPSHOT_REFERENCES_FILE` is set, append
+/// the path (one per line) so obsolete-snapshot detection sees it as used.
+///
+/// Best-effort: does nothing if the variable is unset or the append fails, just
+/// like insta. This exists only because mock replay returns a recorded value
+/// without running an insta assertion, so insta itself never memoizes the file.
+fn memoize_snapshot_reference(snapshot_path: &Path) {
+    if let Ok(ref_file) = std::env::var("INSTA_SNAPSHOT_REFERENCES_FILE") {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(ref_file)
+        {
+            let _ = writeln!(f, "{}", snapshot_path.display());
+        }
+    }
+}
 
 /// Scope `test_info` to a mock of `suffix`, write its request snapshot, and
 /// report where/whether the response should be recorded.
@@ -98,6 +118,12 @@ pub fn assert_json_snapshot_named(
 /// Used by the Python mock layer during replay: the recorded response is loaded
 /// through insta (so the snapshot file format is handled in one place) and
 /// converted back into native Python objects.
+///
+/// Replay is the one path that returns a snapshot's value *without* running an
+/// insta assertion, so insta never memoizes the file as "referenced". To keep
+/// obsolete-snapshot detection accurate we record the reference ourselves,
+/// exactly as insta's own `memoize_snapshot_file` does: append the path to the
+/// file named by `INSTA_SNAPSHOT_REFERENCES_FILE` (set by `pysnaptest unused`).
 #[pyfunction]
 pub fn read_json_snapshot(snapshot_path: PathBuf) -> PyResult<PyObject> {
     let snapshot = Snapshot::from_file(&snapshot_path).map_err(|e| {
@@ -105,6 +131,7 @@ pub fn read_json_snapshot(snapshot_path: PathBuf) -> PyResult<PyObject> {
             "Unable to load snapshot from {snapshot_path:?}: {e}"
         ))
     })?;
+    memoize_snapshot_reference(&snapshot_path);
     match snapshot.contents() {
         SnapshotContents::Text(content) => Python::with_gil(|py| {
             let value: serde_json::Value =

--- a/tests/test_unused.py
+++ b/tests/test_unused.py
@@ -1,0 +1,199 @@
+"""Tests for obsolete-snapshot detection (``pysnaptest.unused``)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from pysnaptest.unused import (
+    delete_snapshot,
+    discover_snapshot_dirs,
+    find_unused_snapshots,
+    owning_stem,
+    read_referenced,
+    sibling_test_stems,
+    snapshot_files,
+)
+
+
+def _write_snapshot(path: Path, body: str = "value") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\nsource: t\n---\n{body}\n", encoding="utf-8")
+    return path
+
+
+def _write_binary_snapshot(path: Path, extension: str, data: bytes) -> Path:
+    """Write a binary snapshot (insta metadata + sidecar) like insta does."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nsource: t\nextension: {extension}\nsnapshot_kind: binary\n---\n",
+        encoding="utf-8",
+    )
+    (path.parent / f"{path.name}.{extension}").write_bytes(data)
+    return path
+
+
+def test_owning_stem_prefers_longest_match():
+    snap = Path("pysnaptest__test_snapshots_test_thing@pysnap.snap")
+    # Both "test" and "test_snapshots" are plausible prefixes; the longer wins.
+    assert owning_stem(snap, {"test", "test_snapshots"}) == "test_snapshots"
+
+
+def test_owning_stem_exact_match():
+    snap = Path("mod__test_main@pysnap.snap")
+    assert owning_stem(snap, {"test_main"}) == "test_main"
+
+
+def test_owning_stem_no_known_stem():
+    snap = Path("mod__test_orphan_thing@pysnap.snap")
+    assert owning_stem(snap, {"test_other"}) is None
+
+
+def test_owning_stem_ignores_non_snapshot_name():
+    assert owning_stem(Path("not-a-snapshot.txt"), {"test_main"}) is None
+
+
+def test_sibling_test_stems(tmp_path: Path):
+    (tmp_path / "test_a.py").write_text("", encoding="utf-8")
+    (tmp_path / "test_b.py").write_text("", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("", encoding="utf-8")
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+    assert sibling_test_stems(snapshots) == {"test_a", "test_b"}
+
+
+def test_snapshot_files_matches_only_committed(tmp_path: Path):
+    snaps = tmp_path / "snapshots"
+    committed = _write_snapshot(snaps / "mod__test_a_x@pysnap.snap")
+    _write_snapshot(snaps / "mod__test_a_x@pysnap.snap.new")  # pending, ignored
+    found = snapshot_files([snaps])
+    assert found == {committed.resolve()}
+
+
+def test_read_referenced_missing_file(tmp_path: Path):
+    assert read_referenced(tmp_path / "does-not-exist.txt") == set()
+
+
+def test_read_referenced_parses_lines(tmp_path: Path):
+    a = _write_snapshot(tmp_path / "snapshots" / "mod__test_a_x@pysnap.snap")
+    ref = tmp_path / "refs.txt"
+    ref.write_text(f"{a}\n\n{a}\n", encoding="utf-8")
+    assert read_referenced(ref) == {a.resolve()}
+
+
+def test_find_unused_only_flags_ran_stems(tmp_path: Path):
+    (tmp_path / "test_a.py").write_text("", encoding="utf-8")
+    (tmp_path / "test_b.py").write_text("", encoding="utf-8")
+    snaps = tmp_path / "snapshots"
+    used_a = _write_snapshot(snaps / "mod__test_a_used@pysnap.snap")
+    unused_a = _write_snapshot(snaps / "mod__test_a_orphan@pysnap.snap")
+    # Owned by test_b, which did NOT run: must not be flagged.
+    unused_b = _write_snapshot(snaps / "mod__test_b_orphan@pysnap.snap")
+
+    result = find_unused_snapshots(
+        referenced=[used_a],
+        snapshot_dirs=[snaps],
+        ran_stems=["test_a"],
+    )
+    assert result == [unused_a.resolve()]
+    assert unused_b.resolve() not in result
+
+
+def test_delete_snapshot_removes_sidecars(tmp_path: Path):
+    snaps = tmp_path / "snapshots"
+    meta = _write_binary_snapshot(
+        snaps / "mod__test_a_x@pysnap.snap", "parquet", b"binary"
+    )
+    sidecar = snaps / "mod__test_a_x@pysnap.snap.parquet"
+
+    removed = delete_snapshot(meta)
+
+    assert set(removed) == {meta, sidecar}
+    assert not meta.exists()
+    assert not sidecar.exists()
+
+
+def test_delete_snapshot_leaves_unrelated_siblings(tmp_path: Path):
+    # Deletion resolves the sidecar through insta's build_binary_path, so a
+    # sibling pending file that merely shares the name prefix is never touched.
+    snaps = tmp_path / "snapshots"
+    meta = _write_snapshot(snaps / "mod__test_a_x@pysnap.snap")
+    pending = _write_snapshot(snaps / "mod__test_a_x@pysnap.snap.new")
+
+    removed = delete_snapshot(meta)
+
+    assert removed == [meta]
+    assert not meta.exists()
+    assert pending.exists()
+
+
+def test_discover_snapshot_dirs(tmp_path: Path):
+    a = tmp_path / "pkg" / "snapshots"
+    b = tmp_path / "other" / "snapshots"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    (tmp_path / "not-snapshots").mkdir()
+    assert discover_snapshot_dirs(tmp_path) == sorted([a, b])
+
+
+# --- End-to-end CLI test ----------------------------------------------------
+
+
+def _make_project(root: Path) -> None:
+    """Create a minimal project with one passing snapshot test."""
+
+    (root / "pytest.ini").write_text(
+        "[pytest]\nINSTA_WORKSPACE_ROOT = .\n", encoding="utf-8"
+    )
+    (root / "test_thing.py").write_text(
+        textwrap.dedent(
+            """
+            from pysnaptest import assert_snapshot
+
+            def test_thing():
+                assert_snapshot("kept")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_cli(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pysnaptest", "unused", *args],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_unused_reports_and_deletes(tmp_path: Path):
+    _make_project(tmp_path)
+
+    # Record the initial snapshot for the real test.
+    subprocess.run(
+        [sys.executable, "-m", "pytest", "--snapshot-update", "-q"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    snaps = tmp_path / "snapshots"
+    kept = snaps / "pysnaptest__test_thing_test_thing@pysnap.snap"
+    assert kept.exists()
+
+    # Add an orphan snapshot owned by the same (existing) test file.
+    orphan = _write_snapshot(snaps / "pysnaptest__test_thing_test_gone@pysnap.snap")
+
+    report = _run_cli(tmp_path)
+    assert report.returncode == 1
+    assert "Found 1 unused snapshot" in report.stdout
+    assert orphan.exists()
+
+    deleted = _run_cli(tmp_path, "--delete")
+    assert deleted.returncode == 0
+    assert "Deleting 1 unused snapshot" in deleted.stdout
+    assert not orphan.exists()
+    assert kept.exists()  # referenced snapshot preserved


### PR DESCRIPTION
## What

Adds obsolete-snapshot detection: a way to find and delete committed snapshots that no test references any more, so snapshot directories don't rot as tests are renamed or removed. This is the Python-tooling equivalent of `cargo insta test --unreferenced`.

## How

Rather than reimplementing reference tracking, this reuses insta's own: when `INSTA_SNAPSHOT_REFERENCES_FILE` is set, insta appends the path of every snapshot it touches during an assertion. The new `pysnaptest.unused` module runs the suite once with that variable pointed at a temp file, then treats any committed `*@pysnap.snap` file not listed as a candidate for deletion.

The one path that bypasses an insta assertion is **mock replay**: `mock_json_snapshot` serves a recorded response through `read_json_snapshot` without asserting, so insta never memoizes it. The Rust `read_json_snapshot` primitive now appends the response path to the same reference file (exactly as insta's own `memoize_snapshot_file` does), so replayed mocks — both request and response snapshots — are correctly seen as referenced and never wrongly deleted. This is verified end-to-end.

## New CLI subcommand

```bash
pysnaptest unused            # run the suite and list unreferenced snapshots
pysnaptest unused --delete   # ...and delete them (plus any binary sidecars)
pysnaptest unused --delete -- -k integration   # forward args to pytest
```

Without `--delete` the command exits non-zero when it finds unreferenced snapshots, so it can gate CI. Scoping is conservative: a snapshot is only reported when the test module that owns it still exists next to the snapshot directory (resolved by matching the filename against sibling test stems, longest match wins), so partial runs are safe.

## Notes

- No new Rust dependencies; the `mocks.rs` change is a small best-effort append mirroring insta's helper.
- `pysnaptest.unused` also exposes the building blocks (`find_unused_snapshots`, `delete_snapshot`, ...) for scripting.
- A pytest-native flag that wires this up automatically is intended to follow in a separate change.

## Tests

Adds `tests/test_unused.py` (unit coverage for stem resolution, discovery, sidecar handling, scoping, plus an end-to-end CLI test). Full suite: 77 passed, 2 skipped. `cargo fmt`/`clippy` clean.
