### PR TITLE
Add readable CSV/JSON diffs for binary DataFrame snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "pythonize",
  "serde",
  "serde_json",
+ "similar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pyo3 = { version = "0.25", features = ["generate-import-lib"] }
 pythonize = "0.25"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.134"
+similar = "2.7"
 
 [features]
 # must be enabled when building with `cargo build`, maturin enables this automatically

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ capabilities that peers don't offer out of the box:
   for free — no other Python tool reads and writes insta snapshots.
 - **First-class DataFrame snapshots.** Snapshot pandas or polars `DataFrame`
   objects directly, serialized as CSV, JSON, parquet, or insta's binary format.
+  Large binary DataFrames can store compactly yet still show a readable CSV/JSON
+  diff on mismatch.
 - **Automatic serialization of rich objects.** JSON snapshots normalize Pydantic
   models, dataclasses, enums and common standard-library types (`datetime`,
   `UUID`, `Decimal`, `set`, ...) into JSON automatically — no manual
@@ -133,6 +135,26 @@ assert_json_snapshot(
 
 Pass a `DataFrame` to `assert_dataframe_snapshot`; `assert_json_snapshot` raises
 a `TypeError` for DataFrames.
+
+### Readable diffs for large binary DataFrames
+
+For big datasets, store the snapshot in a compact binary format (`parquet` for
+pandas, `bin` for polars) but still get a human-readable diff when it changes.
+Equality is insta's exact byte comparison of the stored binary; on a mismatch,
+`readable_diff` decompresses the committed snapshot and shows a CSV or JSON diff
+of the two DataFrames:
+
+```python
+assert_dataframe_snapshot(
+    big_df,
+    dataframe_snapshot_format="parquet",  # "bin" for polars
+    readable_diff="csv",                  # or "json"
+)
+```
+
+`readable_diff` defaults to `None`, which keeps the byte-only behavior. It also
+works through the `@snapshot` decorator (`@snapshot(dataframe_snapshot_format=
+"parquet", readable_diff="csv")`).
 
 ### Which API do I use?
 

--- a/python/pysnaptest/assertion.py
+++ b/python/pysnaptest/assertion.py
@@ -8,8 +8,9 @@ structures.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union, overload
-from functools import wraps
+from functools import partial, wraps
 import asyncio
+import io
 
 from ._pysnaptest import (
     assert_json_snapshot as _assert_json_snapshot,
@@ -168,6 +169,43 @@ def try_is_polars_df(maybe_df: Any) -> bool:
     return isinstance(maybe_df, pl.DataFrame)
 
 
+def _binary_dataframe_to_text(
+    data: bytes, library: str, extension: str, readable_diff: str
+) -> str:
+    """Decode a binary DataFrame snapshot and render it as CSV or JSON text.
+
+    This is the only Python step in the readable-diff flow: Rust owns the byte
+    comparison and calls this back for the committed and new bytes when they
+    differ. ``data`` is decoded with the same library (``"pandas"``/``"polars"``)
+    and format as the snapshot so the two renderings are directly comparable.
+    """
+
+    buffer = io.BytesIO(data)
+    if library == "pandas":
+        import pandas as pd
+
+        frame = pd.read_parquet(buffer)
+        if readable_diff == "csv":
+            return frame.to_csv()
+        if readable_diff == "json":
+            return frame.to_json(orient="records", indent=2)
+    else:
+        import polars as pl
+
+        frame = (
+            pl.DataFrame.deserialize(buffer, format="binary")
+            if extension == "bin"
+            else pl.read_parquet(buffer)
+        )
+        if readable_diff == "csv":
+            return frame.write_csv()
+        if readable_diff == "json":
+            return frame.write_json()
+    raise ValueError(
+        f"Unsupported readable_diff format: {readable_diff!r}. Use 'csv' or 'json'."
+    )
+
+
 def assert_pandas_dataframe_snapshot(
     df: pd.DataFrame,
     snapshot_path: Optional[str] = None,
@@ -175,6 +213,7 @@ def assert_pandas_dataframe_snapshot(
     redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
+    readable_diff: Optional[str] = None,
     *args,
     **kwargs,
 ) -> None:
@@ -187,6 +226,9 @@ def assert_pandas_dataframe_snapshot(
         redactions: Mapping of selectors to replacement values.
         dataframe_snapshot_format: One of ``"csv"``, ``"json"`` or ``"parquet"``.
         allow_duplicates: Whether to allow duplicate snapshot names.
+        readable_diff: For the binary ``"parquet"`` format only, show a readable
+            ``"csv"`` or ``"json"`` diff on mismatch instead of just a byte
+            difference. ``None`` (default) keeps the byte-only behavior.
         *args: Positional arguments forwarded to the DataFrame export method.
         **kwargs: Keyword arguments forwarded to the DataFrame export method.
     """
@@ -203,12 +245,23 @@ def assert_pandas_dataframe_snapshot(
         )
     elif dataframe_snapshot_format == "parquet":
         result = df.to_parquet(engine="pyarrow")
+        renderer = (
+            partial(
+                _binary_dataframe_to_text,
+                library="pandas",
+                extension=dataframe_snapshot_format,
+                readable_diff=readable_diff,
+            )
+            if readable_diff is not None
+            else None
+        )
         assert_binary_snapshot(
             result,
             snapshot_path,
             snapshot_name,
             extension=dataframe_snapshot_format,
             allow_duplicates=allow_duplicates,
+            _readable_diff_renderer=renderer,
         )
     else:
         raise ValueError(
@@ -223,6 +276,7 @@ def assert_polars_dataframe_snapshot(
     redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
+    readable_diff: Optional[str] = None,
     *args,
     **kwargs,
 ) -> None:
@@ -235,6 +289,9 @@ def assert_polars_dataframe_snapshot(
         redactions: Mapping of selectors to replacement values.
         dataframe_snapshot_format: One of ``"csv"``, ``"json"`` or ``"bin"``.
         allow_duplicates: Whether to allow duplicate snapshot names.
+        readable_diff: For the binary ``"bin"`` format only, show a readable
+            ``"csv"`` or ``"json"`` diff on mismatch instead of just a byte
+            difference. ``None`` (default) keeps the byte-only behavior.
         *args: Positional arguments forwarded to the DataFrame export method.
         **kwargs: Keyword arguments forwarded to the DataFrame export method.
     """
@@ -251,12 +308,23 @@ def assert_polars_dataframe_snapshot(
         )
     elif dataframe_snapshot_format == "bin":
         result = df.serialize(format="binary", *args, **kwargs)
+        renderer = (
+            partial(
+                _binary_dataframe_to_text,
+                library="polars",
+                extension=dataframe_snapshot_format,
+                readable_diff=readable_diff,
+            )
+            if readable_diff is not None
+            else None
+        )
         assert_binary_snapshot(
             result,
             snapshot_path,
             snapshot_name,
             extension=dataframe_snapshot_format,
             allow_duplicates=allow_duplicates,
+            _readable_diff_renderer=renderer,
         )
     else:
         raise ValueError(
@@ -271,6 +339,7 @@ def assert_dataframe_snapshot(
     redactions: Optional[Dict[str, Union[str, int, None]]] = None,
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
+    readable_diff: Optional[str] = None,
     *args,
     **kwargs,
 ) -> None:
@@ -284,6 +353,9 @@ def assert_dataframe_snapshot(
         dataframe_snapshot_format: Format to serialize the DataFrame as. Supported
             values are ``"csv"``, ``"json"``, ``"parquet"`` and ``"bin"``.
         allow_duplicates: Whether to allow duplicate snapshot names.
+        readable_diff: For the binary formats (``"parquet"``/``"bin"``) only, show
+            a readable ``"csv"`` or ``"json"`` diff on mismatch instead of just a
+            byte difference. ``None`` (default) keeps the byte-only behavior.
         *args: Positional arguments forwarded to the DataFrame export method.
         **kwargs: Keyword arguments forwarded to the DataFrame export method.
     """
@@ -296,6 +368,7 @@ def assert_dataframe_snapshot(
             redactions,
             dataframe_snapshot_format,
             allow_duplicates,
+            readable_diff,
             *args,
             **kwargs,
         )
@@ -307,6 +380,7 @@ def assert_dataframe_snapshot(
             redactions,
             dataframe_snapshot_format,
             allow_duplicates,
+            readable_diff,
             *args,
             **kwargs,
         )
@@ -322,6 +396,7 @@ def assert_binary_snapshot(
     snapshot_name: Optional[str] = None,
     extension: str = "bin",
     allow_duplicates: bool = False,
+    _readable_diff_renderer: Optional[Callable[[bytes], str]] = None,
 ) -> None:
     """Assert that binary data matches the stored snapshot.
 
@@ -331,10 +406,13 @@ def assert_binary_snapshot(
         snapshot_name: Optional name override for the snapshot file.
         extension: File extension to use when saving the snapshot.
         allow_duplicates: Whether to allow duplicate snapshot names.
+        _readable_diff_renderer: Optional callback that decodes binary snapshot
+            bytes into readable text (CSV/JSON) so a mismatch shows a readable
+            diff. Supplied internally by the DataFrame snapshot helpers.
     """
 
     test_info = extract_from_pytest_env(snapshot_path, snapshot_name, allow_duplicates)
-    _assert_binary_snapshot(test_info, extension, result)
+    _assert_binary_snapshot(test_info, extension, result, _readable_diff_renderer)
 
 
 def assert_snapshot(
@@ -364,6 +442,7 @@ def insta_snapshot(
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
     custom_encoder: Optional[Dict[type, Callable[[Any], Any]]] = None,
+    readable_diff: Optional[str] = None,
 ) -> None:
     """Dispatch a value to the appropriate snapshot assertion.
 
@@ -379,6 +458,8 @@ def insta_snapshot(
         allow_duplicates: Whether to allow duplicate snapshot names.
         custom_encoder: Optional mapping of types to encoder callables used when
             normalizing JSON snapshots.
+        readable_diff: For binary DataFrame formats, show a ``"csv"``/``"json"``
+            diff on mismatch. ``None`` (default) keeps byte-only reporting.
     """
 
     if isinstance(result, (dict, list)):
@@ -405,6 +486,7 @@ def insta_snapshot(
             redactions,
             dataframe_snapshot_format,
             allow_duplicates,
+            readable_diff,
         )
     elif is_jsonable_object(result):
         assert_json_snapshot(
@@ -439,6 +521,7 @@ def snapshot(
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
     custom_encoder: Optional[Dict[type, Callable[[Any], Any]]] = None,
+    readable_diff: Optional[str] = None,
 ) -> Callable:  # noqa: F811
     ...
 
@@ -452,6 +535,7 @@ def snapshot(  # noqa: F811
     dataframe_snapshot_format: str = "csv",
     allow_duplicates: bool = False,
     custom_encoder: Optional[Dict[type, Callable[[Any], Any]]] = None,
+    readable_diff: Optional[str] = None,
 ) -> Callable:
     """Decorator that snapshots the return value of ``func``.
 
@@ -464,6 +548,9 @@ def snapshot(  # noqa: F811
         allow_duplicates: Whether to allow duplicate snapshot names.
         custom_encoder: Optional mapping of types to encoder callables used when
             normalizing JSON snapshots.
+        readable_diff: For binary DataFrame formats (``"parquet"``/``"bin"``),
+            show a readable ``"csv"``/``"json"`` diff on mismatch instead of just
+            a byte difference. ``None`` (default) keeps byte-only reporting.
 
     Returns:
         Callable: The wrapped function.
@@ -486,6 +573,7 @@ def snapshot(  # noqa: F811
                     dataframe_snapshot_format=dataframe_snapshot_format,
                     allow_duplicates=allow_duplicates,
                     custom_encoder=custom_encoder,
+                    readable_diff=readable_diff,
                 )
 
             return asserted_func
@@ -501,6 +589,7 @@ def snapshot(  # noqa: F811
                 dataframe_snapshot_format=dataframe_snapshot_format,
                 allow_duplicates=allow_duplicates,
                 custom_encoder=custom_encoder,
+                readable_diff=readable_diff,
             )
 
         return asserted_func

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,9 @@ use std::{
 use csv::ReaderBuilder;
 use insta::output::SnapshotPrinter;
 use insta::Snapshot;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyAssertionError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 
 /// Binds insta settings (path, redactions) and asserts a JSON snapshot under an
 /// explicit `snapshot_name`.
@@ -99,19 +100,81 @@ pub fn assert_csv_snapshot(
 }
 
 #[pyfunction]
+#[pyo3(signature = (test_info, extension, result, readable_diff_renderer=None))]
 pub fn assert_binary_snapshot(
+    py: Python<'_>,
     test_info: &SnapshotInfo,
     extension: &str,
     result: Vec<u8>,
+    readable_diff_renderer: Option<PyObject>,
 ) -> PyResult<()> {
     let snapshot_name = test_info.snapshot_name();
     let settings: insta::Settings = test_info.try_into()?;
     let snapshot_label = snapshot_name.clone();
-    panic::run_snapshot_assertion(&snapshot_label, || {
+
+    // Fast path: without a renderer this is a plain byte-compared binary snapshot.
+    let Some(renderer) = readable_diff_renderer else {
+        return panic::run_snapshot_assertion(&snapshot_label, || {
+            settings.bind(|| {
+                insta::assert_binary_snapshot!(
+                    format!("{snapshot_name}.{extension}").as_str(),
+                    result
+                );
+            });
+        });
+    };
+
+    // Equality is still insta's exact byte comparison. Rust owns the whole
+    // compare/mismatch/raise flow; the renderer is the only Python step (it
+    // decodes the binary DataFrame, which needs pandas/polars). Read the
+    // committed sidecar up front so a mismatch can be rendered against it.
+    let module_prefix = module_path!().replace("::", "__");
+    let sidecar = test_info.snapshot_folder().join(format!(
+        "{module_prefix}__{snapshot_name}@pysnap.snap.{extension}"
+    ));
+    let previous = std::fs::read(&sidecar).ok();
+    let new_bytes = result.clone();
+
+    let matched = panic::run_snapshot_assertion_matched(&snapshot_label, || {
         settings.bind(|| {
             insta::assert_binary_snapshot!(format!("{snapshot_name}.{extension}").as_str(), result);
         });
-    })
+    })?;
+    if matched {
+        return Ok(());
+    }
+
+    let base = format!(
+        "snapshot '{snapshot_label}' did not match the stored value (readable diff below). \
+         Update the snapshot if this change is intentional."
+    );
+    let Some(previous) = previous else {
+        // First run: no committed snapshot to diff against.
+        return Err(PyAssertionError::new_err(base));
+    };
+
+    let renderer = renderer.bind(py);
+    let old_text: String = renderer.call1((PyBytes::new(py, &previous),))?.extract()?;
+    let new_text: String = renderer.call1((PyBytes::new(py, &new_bytes),))?.extract()?;
+    let diff = render_text_diff(&old_text, &new_text, Some("committed"), Some("new"));
+    Err(PyAssertionError::new_err(format!("{base}\n\n{diff}")))
+}
+
+/// Renders a unified diff between two text renderings using the same diff engine
+/// insta uses (`similar`). Used to show a human-readable CSV/JSON diff for binary
+/// DataFrame snapshots whose raw bytes differ.
+#[pyfunction]
+#[pyo3(signature = (old, new, old_label=None, new_label=None))]
+pub fn render_text_diff(
+    old: &str,
+    new: &str,
+    old_label: Option<&str>,
+    new_label: Option<&str>,
+) -> String {
+    let diff = similar::TextDiff::from_lines(old, new);
+    let mut unified = diff.unified_diff();
+    unified.header(old_label.unwrap_or("committed"), new_label.unwrap_or("new"));
+    unified.to_string()
 }
 
 #[pyfunction]
@@ -350,6 +413,7 @@ fn pysnaptest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("SNAPSHOT_SUFFIX", SNAPSHOT_FILE_SUFFIX)?;
     m.add_function(wrap_pyfunction!(assert_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_binary_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(render_text_diff, m)?)?;
     m.add_function(wrap_pyfunction!(assert_json_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(assert_csv_snapshot, m)?)?;
     m.add_function(wrap_pyfunction!(prepare_mock_call, m)?)?;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -68,24 +68,41 @@ fn panic_message(payload: &(dyn Any + Send)) -> Option<String> {
     }
 }
 
-/// Builds the `AssertionError` message for a failed assertion.
+/// Classified result of running an insta snapshot assertion under our guard.
+enum AssertionOutcome {
+    /// The snapshot matched (or was updated).
+    Matched,
+    /// insta's expected mismatch panic fired; insta printed the diff to stdout.
+    Mismatch,
+    /// An unexpected panic (a real bug); carries its surfaced message.
+    Error(String),
+}
+
+/// Runs an insta assertion under the quiet panic hook and classifies the result.
 ///
-/// insta's mismatch panic is `snapshot assertion for '...' failed in line N`,
-/// where the line number points at Rust internals and is noise for a Python
-/// user; that case gets a friendly hint. Any other panic (an unexpected bug)
-/// keeps its original message.
-fn assertion_message(snapshot_name: &str, payload: &(dyn Any + Send)) -> String {
-    let raw = panic_message(payload);
-    if raw
-        .as_deref()
-        .is_some_and(|m| m.starts_with("snapshot assertion for"))
-    {
-        format!(
-            "snapshot '{snapshot_name}' did not match the stored value (see the diff above). \
-             Update the snapshot if this change is intentional."
-        )
-    } else {
-        raw.unwrap_or_else(|| format!("snapshot '{snapshot_name}' assertion failed"))
+/// insta signals a snapshot mismatch by panicking with a message starting
+/// `snapshot assertion for '...'`; that is the one panic we treat as an expected
+/// outcome. Any other panic is an unexpected bug and its message is preserved.
+fn run_assertion<F: FnOnce()>(snapshot_name: &str, assertion: F) -> AssertionOutcome {
+    let guard = AssertionGuard::enter();
+    let outcome = panic::catch_unwind(AssertUnwindSafe(assertion));
+    drop(guard);
+
+    match outcome {
+        Ok(()) => AssertionOutcome::Matched,
+        Err(payload) => {
+            let raw = panic_message(payload.as_ref());
+            if raw
+                .as_deref()
+                .is_some_and(|m| m.starts_with("snapshot assertion for"))
+            {
+                AssertionOutcome::Mismatch
+            } else {
+                AssertionOutcome::Error(
+                    raw.unwrap_or_else(|| format!("snapshot '{snapshot_name}' assertion failed")),
+                )
+            }
+        }
     }
 }
 
@@ -93,15 +110,31 @@ fn assertion_message(snapshot_name: &str, payload: &(dyn Any + Send)) -> String 
 /// panicking) into a Python `AssertionError`. insta prints the diff to stdout
 /// before it panics, so the raised error only needs to say what to do next.
 pub fn run_snapshot_assertion<F: FnOnce()>(snapshot_name: &str, assertion: F) -> PyResult<()> {
-    let guard = AssertionGuard::enter();
-    let outcome = panic::catch_unwind(AssertUnwindSafe(assertion));
-    drop(guard);
-
-    match outcome {
-        Ok(()) => Ok(()),
-        Err(payload) => Err(PyAssertionError::new_err(assertion_message(
-            snapshot_name,
-            payload.as_ref(),
+    match run_assertion(snapshot_name, assertion) {
+        AssertionOutcome::Matched => Ok(()),
+        AssertionOutcome::Mismatch => Err(PyAssertionError::new_err(format!(
+            "snapshot '{snapshot_name}' did not match the stored value (see the diff above). \
+             Update the snapshot if this change is intentional."
         ))),
+        AssertionOutcome::Error(message) => Err(PyAssertionError::new_err(message)),
+    }
+}
+
+/// Runs an insta assertion but reports the outcome as a boolean instead of
+/// raising on a snapshot mismatch.
+///
+/// Returns `Ok(true)` when the snapshot matched (or was updated) and `Ok(false)`
+/// for insta's expected mismatch panic. Any other (unexpected) panic is still
+/// surfaced as a Python `AssertionError`. This lets a caller enrich the failure
+/// (e.g. render a readable CSV/JSON diff for a binary DataFrame snapshot) while
+/// insta still writes its pending `.new` file as usual.
+pub fn run_snapshot_assertion_matched<F: FnOnce()>(
+    snapshot_name: &str,
+    assertion: F,
+) -> PyResult<bool> {
+    match run_assertion(snapshot_name, assertion) {
+        AssertionOutcome::Matched => Ok(true),
+        AssertionOutcome::Mismatch => Ok(false),
+        AssertionOutcome::Error(message) => Err(PyAssertionError::new_err(message)),
     }
 }

--- a/tests/test_readable_diff.py
+++ b/tests/test_readable_diff.py
@@ -1,0 +1,181 @@
+"""Tests for readable (CSV/JSON) diffs on binary DataFrame snapshots.
+
+Equality is still insta's exact byte comparison of the stored binary (parquet
+for pandas, ``bin`` for polars). When ``readable_diff`` is set and the bytes
+differ, the committed snapshot is decompressed and a CSV/JSON unified diff is
+attached to the ``AssertionError``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pysnaptest import assert_dataframe_snapshot
+from pysnaptest._pysnaptest import render_text_diff
+
+try:
+    import pandas as pd
+
+    PANDAS_UNAVAILABLE = False
+except ImportError:
+    PANDAS_UNAVAILABLE = True
+
+try:
+    import polars as pl
+
+    POLARS_UNAVAILABLE = False
+except ImportError:
+    POLARS_UNAVAILABLE = True
+
+
+def _serialize(df, fmt: str) -> bytes:
+    """Serialize a DataFrame the same way the assertion path does."""
+
+    if fmt == "parquet":
+        return df.to_parquet(engine="pyarrow")
+    return df.serialize(format="binary")  # polars "bin"
+
+
+def _commit_snapshot(df, snap_dir: Path, name: str, fmt: str) -> None:
+    """Hand-write the committed binary snapshot (insta metadata + sidecar).
+
+    This mirrors exactly what insta writes for a binary snapshot, so the
+    assertion path compares against it byte-for-byte without needing insta's
+    update mode (whose behavior insta caches per-process).
+    """
+
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    metadata = snap_dir / f"pysnaptest__{name}@pysnap.snap"
+    metadata.write_text(
+        f"---\nsource: src/lib.rs\nextension: {fmt}\nsnapshot_kind: binary\n---\n",
+        encoding="utf-8",
+    )
+    sidecar = snap_dir / f"pysnaptest__{name}@pysnap.snap.{fmt}"
+    sidecar.write_bytes(_serialize(df, fmt))
+
+
+def test_render_text_diff_basic():
+    diff = render_text_diff("a\nb\nc\n", "a\nB\nc\n", "committed", "new")
+    assert "committed" in diff
+    assert "new" in diff
+    assert "-b" in diff
+    assert "+B" in diff
+
+
+def test_render_text_diff_default_labels():
+    diff = render_text_diff("x\n", "y\n")
+    assert "committed" in diff
+    assert "new" in diff
+
+
+@pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="pandas is an optional dependency")
+def test_pandas_parquet_readable_diff_csv(tmp_path: Path):
+    snap_dir = tmp_path / "snapshots"
+    name = "test_readable_diff_pandas_csv"
+    old = pd.DataFrame({"id": [1, 2], "name": ["foo", "bar"]})
+    _commit_snapshot(old, snap_dir, name, "parquet")
+
+    new = pd.DataFrame({"id": [1, 2], "name": ["foo", "CHANGED"]})
+    with pytest.raises(AssertionError) as exc:
+        assert_dataframe_snapshot(
+            new,
+            snapshot_path=str(snap_dir),
+            snapshot_name=name,
+            dataframe_snapshot_format="parquet",
+            readable_diff="csv",
+            allow_duplicates=True,
+        )
+
+    message = str(exc.value)
+    assert "readable diff below" in message
+    assert "bar" in message  # value from the committed snapshot
+    assert "CHANGED" in message  # value from the new DataFrame
+
+
+@pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="pandas is an optional dependency")
+def test_pandas_parquet_readable_diff_json(tmp_path: Path):
+    snap_dir = tmp_path / "snapshots"
+    name = "test_readable_diff_pandas_json"
+    old = pd.DataFrame({"id": [1], "name": ["foo"]})
+    _commit_snapshot(old, snap_dir, name, "parquet")
+
+    new = pd.DataFrame({"id": [1], "name": ["bar"]})
+    with pytest.raises(AssertionError) as exc:
+        assert_dataframe_snapshot(
+            new,
+            snapshot_path=str(snap_dir),
+            snapshot_name=name,
+            dataframe_snapshot_format="parquet",
+            readable_diff="json",
+            allow_duplicates=True,
+        )
+
+    message = str(exc.value)
+    assert '"name"' in message  # JSON-rendered rows
+    assert "foo" in message
+    assert "bar" in message
+
+
+@pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="pandas is an optional dependency")
+def test_pandas_parquet_readable_diff_matches(tmp_path: Path):
+    snap_dir = tmp_path / "snapshots"
+    name = "test_readable_diff_pandas_match"
+    df = pd.DataFrame({"id": [1, 2], "name": ["foo", "bar"]})
+    _commit_snapshot(df, snap_dir, name, "parquet")
+
+    # Same DataFrame -> identical bytes -> passes, no diff raised.
+    assert_dataframe_snapshot(
+        df,
+        snapshot_path=str(snap_dir),
+        snapshot_name=name,
+        dataframe_snapshot_format="parquet",
+        readable_diff="csv",
+        allow_duplicates=True,
+    )
+
+
+@pytest.mark.skipif(PANDAS_UNAVAILABLE, reason="pandas is an optional dependency")
+def test_pandas_parquet_byte_only_default(tmp_path: Path):
+    snap_dir = tmp_path / "snapshots"
+    name = "test_readable_diff_pandas_byteonly"
+    old = pd.DataFrame({"id": [1], "name": ["foo"]})
+    _commit_snapshot(old, snap_dir, name, "parquet")
+
+    new = pd.DataFrame({"id": [1], "name": ["bar"]})
+    with pytest.raises(AssertionError) as exc:
+        assert_dataframe_snapshot(
+            new,
+            snapshot_path=str(snap_dir),
+            snapshot_name=name,
+            dataframe_snapshot_format="parquet",
+            allow_duplicates=True,
+        )
+
+    # Without readable_diff the message stays byte-only (no rendered diff).
+    assert "readable diff below" not in str(exc.value)
+
+
+@pytest.mark.skipif(POLARS_UNAVAILABLE, reason="polars is an optional dependency")
+def test_polars_bin_readable_diff_csv(tmp_path: Path):
+    snap_dir = tmp_path / "snapshots"
+    name = "test_readable_diff_polars_csv"
+    old = pl.DataFrame({"id": [1, 2], "name": ["foo", "bar"]})
+    _commit_snapshot(old, snap_dir, name, "bin")
+
+    new = pl.DataFrame({"id": [1, 2], "name": ["foo", "CHANGED"]})
+    with pytest.raises(AssertionError) as exc:
+        assert_dataframe_snapshot(
+            new,
+            snapshot_path=str(snap_dir),
+            snapshot_name=name,
+            dataframe_snapshot_format="bin",
+            readable_diff="csv",
+            allow_duplicates=True,
+        )
+
+    message = str(exc.value)
+    assert "readable diff below" in message
+    assert "bar" in message
+    assert "CHANGED" in message


### PR DESCRIPTION
Store large DataFrames compactly as a binary snapshot (`parquet` for pandas,
`bin` for polars) while still getting a human-readable diff when the data
changes.

```python
assert_dataframe_snapshot(big_df, dataframe_snapshot_format="parquet", readable_diff="csv")
```

## How it works
Equality stays insta's exact byte comparison. **Rust owns the entire
compare -> mismatch -> raise flow.** On a byte mismatch, `assert_binary_snapshot`
reads the committed sidecar and calls a Python renderer (`bytes -> str`) for both
the old and new bytes, renders a unified diff with insta's `similar` engine, and
attaches it to the `AssertionError`. The renderer is the only Python step, since
decoding parquet/binary DataFrames requires pandas/polars.

- New `readable_diff="csv"|"json"` option on `assert_dataframe_snapshot` and the
  `@snapshot` decorator. Defaults to `None` (byte-only), so existing behavior is
  unchanged.
- New Rust primitives: `render_text_diff` and `run_snapshot_assertion_matched`;
  `assert_binary_snapshot` gains an optional renderer callback.
- One small Python helper decodes a binary DataFrame snapshot to CSV/JSON text.

Tests: 84 passed, 2 skipped. `cargo fmt --check` and `cargo clippy --lib` clean.
