### PR TITLE
Fix snapshot path resolution to be independent of the process CWD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "pysnaptest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "csv",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysnaptest"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 include = [
     "/pyproject.toml",

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ function:
 ```python
 from pysnaptest import snapshot
 
+
 @snapshot
 def test_basic():
     return {"hello": "world"}
@@ -62,6 +63,7 @@ You can also assert snapshots directly without using a decorator:
 
 ```python
 from pysnaptest import assert_json_snapshot
+
 
 def test_direct():
     data = {"hello": "world"}
@@ -74,6 +76,7 @@ return value:
 ```python
 from pysnaptest import patch_json_snapshot, snapshot
 from my_project.main import use_http_request
+
 
 @patch_json_snapshot("my_project.main.http_request")
 @snapshot
@@ -94,9 +97,11 @@ from datetime import date
 from pydantic import BaseModel
 from pysnaptest import snapshot
 
+
 class Event(BaseModel):
     name: str
     happened_on: date
+
 
 @snapshot
 def test_events():
@@ -148,7 +153,7 @@ of the two DataFrames:
 assert_dataframe_snapshot(
     big_df,
     dataframe_snapshot_format="parquet",  # "bin" for polars
-    readable_diff="csv",                  # or "json"
+    readable_diff="csv",  # or "json"
 )
 ```
 

--- a/python/pysnaptest/_pysnaptest.pyi
+++ b/python/pysnaptest/_pysnaptest.pyi
@@ -19,6 +19,7 @@ class SnapshotInfo:
         snapshot_path_override: Optional[_StrPath] = ...,
         snapshot_name_override: Optional[str] = ...,
         allow_duplicates: bool = ...,
+        test_file_override: Optional[_StrPath] = ...,
     ) -> "SnapshotInfo":
         """Build snapshot info from the ``PYTEST_CURRENT_TEST`` environment."""
         ...

--- a/python/pysnaptest/assertion.py
+++ b/python/pysnaptest/assertion.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union, overload
 from functools import partial, wraps
 import asyncio
 import io
+import os
 
 from ._pysnaptest import (
     assert_json_snapshot as _assert_json_snapshot,
@@ -69,6 +70,7 @@ def extract_from_pytest_env(
         snapshot_path_override=snapshot_path,
         snapshot_name_override=snapshot_name,
         allow_duplicates=allow_duplicates,
+        test_file_override=os.environ.get("PYSNAPTEST_TEST_FILE"),
     )
 
 

--- a/python/pysnaptest/pytest_plugin.py
+++ b/python/pysnaptest/pytest_plugin.py
@@ -56,3 +56,19 @@ def pytest_configure(config: "pytest.Config") -> None:
         os.environ["INSTA_UPDATE"] = "always"
     elif config.getoption("--snapshot-new"):
         os.environ["INSTA_UPDATE"] = "new"
+
+
+def pytest_runtest_setup(item: "pytest.Item") -> None:
+    """Record the running test's absolute source-file path.
+
+    pysnaptest's Rust layer otherwise derives the test file location from the
+    rootdir-relative ``PYTEST_CURRENT_TEST`` node id and probes it against the
+    process working directory, which breaks whenever pytest is invoked from a
+    directory other than its rootdir. ``item.path`` is always absolute, so
+    exposing it here keeps snapshot resolution correct regardless of the
+    invocation directory.
+    """
+
+    test_file = getattr(item, "path", None) or getattr(item, "fspath", None)
+    if test_file is not None:
+        os.environ["PYSNAPTEST_TEST_FILE"] = str(test_file)

--- a/src/common.rs
+++ b/src/common.rs
@@ -343,8 +343,7 @@ mod tests {
 
         // A rootdir-relative node id that does NOT exist relative to cwd.
         let info: PytestInfo = "pkg/nested/test_thing.py::test_a".parse().unwrap();
-        let snapshot_info =
-            SnapshotInfo::from_pytest_info(info, Some(test_file.clone())).unwrap();
+        let snapshot_info = SnapshotInfo::from_pytest_info(info, Some(test_file.clone())).unwrap();
 
         // Folder is next to the real test file, mirroring insta.
         assert_eq!(
@@ -368,8 +367,9 @@ mod tests {
     /// absolute test file is provided.
     #[test]
     fn test_resolve_without_test_file_errors_on_missing_path() {
-        let info: PytestInfo =
-            "does/not/exist/anywhere/test_missing.py::test_a".parse().unwrap();
+        let info: PytestInfo = "does/not/exist/anywhere/test_missing.py::test_a"
+            .parse()
+            .unwrap();
         let result = SnapshotInfo::from_pytest_info(info, None);
         assert!(
             result.is_err(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -73,6 +73,24 @@ impl PytestInfo {
     pub fn test_path_raw(&self) -> PathBuf {
         Path::new(&self.test_path).to_path_buf()
     }
+
+    /// Resolve the absolute path to the running test's source file.
+    ///
+    /// The path component of `PYTEST_CURRENT_TEST` (exposed here via
+    /// [`Self::test_path_raw`]) is always relative to pytest's *rootdir*, not to
+    /// the process working directory. When pytest supplies the test file's
+    /// absolute path (its plugin reads `item.path`, which pytest guarantees to
+    /// be absolute) we use it directly so snapshot resolution is independent of
+    /// the invocation directory. Only when no such path is available do we fall
+    /// back to the legacy [`Self::test_path`] probing, which is relative to the
+    /// current working directory and therefore correct only when pytest is
+    /// invoked from its rootdir.
+    fn resolve_test_file(&self, test_file: Option<PathBuf>) -> Result<PathBuf, PytestInfoError> {
+        match test_file {
+            Some(path) => Ok(path),
+            None => self.test_path(),
+        }
+    }
 }
 
 impl FromStr for PytestInfo {
@@ -104,23 +122,34 @@ pub struct SnapshotInfo {
     pub(crate) allow_duplicates: bool,
 }
 
-impl TryFrom<PytestInfo> for SnapshotInfo {
-    type Error = PyErr;
-    fn try_from(value: PytestInfo) -> Result<Self, Self::Error> {
-        let test_file_dir = value
-            .test_path()?
+impl SnapshotInfo {
+    /// Build a [`SnapshotInfo`] from the active pytest test.
+    ///
+    /// `test_file`, when provided, is the absolute path to the test's source
+    /// file (supplied by the pytest plugin from `item.path`). The snapshot
+    /// folder is resolved from that file's directory, keeping snapshots next to
+    /// the test regardless of the process working directory. The snapshot name
+    /// and the stored `Test File Path` description remain derived from the
+    /// rootdir-relative `PYTEST_CURRENT_TEST` node id, so committed snapshots
+    /// are unaffected.
+    pub(crate) fn from_pytest_info(
+        info: PytestInfo,
+        test_file: Option<PathBuf>,
+    ) -> Result<Self, PyErr> {
+        let test_file_dir = info
+            .resolve_test_file(test_file)?
             .canonicalize()?
             .parent()
             .ok_or_else(|| {
                 PyValueError::new_err(format!(
                     "Invalid test_path: {:?}, not yielding a parent directory",
-                    value.test_path_raw()
+                    info.test_path_raw()
                 ))
             })?
             .join("snapshots");
 
-        let test_name = &value.test_name;
-        let test_path = value.test_path_raw();
+        let test_name = &info.test_name;
+        let test_path = info.test_path_raw();
         let file_name = test_path.file_stem().and_then(|s| s.to_str());
 
         let name = if let Some(f) = file_name {
@@ -131,13 +160,11 @@ impl TryFrom<PytestInfo> for SnapshotInfo {
         Ok(Self {
             snapshot_folder: test_file_dir,
             snapshot_name: name,
-            relative_test_file_path: Some(value.test_path()?.to_string_lossy().to_string()),
+            relative_test_file_path: Some(info.test_path_raw().to_string_lossy().to_string()),
             allow_duplicates: false,
         })
     }
-}
 
-impl SnapshotInfo {
     pub(crate) fn counters<'a>() -> MutexGuard<'a, BTreeMap<String, usize>> {
         TEST_NAME_COUNTERS.lock().unwrap_or_else(|x| x.into_inner())
     }
@@ -286,6 +313,7 @@ mod tests {
             Some("folder_path_override".into()),
             Some("snapshot_name_override".into()),
             false,
+            None,
         )
         .unwrap();
         insta::assert_debug_snapshot!(snapshot_info);
@@ -295,5 +323,57 @@ mod tests {
         insta::assert_snapshot!(snapshot_info.snapshot_name(), @"snapshot_name_override-2");
         insta::assert_snapshot!(snapshot_info.last_snapshot_name(), @"snapshot_name_override-2");
         insta::assert_snapshot!(snapshot_info.next_snapshot_name(), @"snapshot_name_override-3");
+    }
+
+    /// The snapshot folder must be derived from the *test file's* directory, not
+    /// from the process working directory. When the pytest plugin supplies the
+    /// test file's absolute path, resolution must ignore `current_dir()` and the
+    /// rootdir-relative node id path entirely.
+    #[test]
+    fn test_resolve_uses_absolute_test_file_not_cwd() {
+        let tmp = std::env::temp_dir().join(format!(
+            "pysnaptest_resolve_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        let test_dir = tmp.join("a").join("b");
+        std::fs::create_dir_all(&test_dir).unwrap();
+        let test_file = test_dir.join("test_thing.py");
+        std::fs::write(&test_file, b"# test").unwrap();
+
+        // A rootdir-relative node id that does NOT exist relative to cwd.
+        let info: PytestInfo = "pkg/nested/test_thing.py::test_a".parse().unwrap();
+        let snapshot_info =
+            SnapshotInfo::from_pytest_info(info, Some(test_file.clone())).unwrap();
+
+        // Folder is next to the real test file, mirroring insta.
+        assert_eq!(
+            snapshot_info.snapshot_folder(),
+            &test_dir.canonicalize().unwrap().join("snapshots")
+        );
+        // Name is still derived from the node id's file stem + test name.
+        assert_eq!(snapshot_info.snapshot_name, "test_thing_test_a");
+        // The stored description keeps the rootdir-relative node id path.
+        assert_eq!(
+            snapshot_info.relative_test_file_path.as_deref(),
+            Some("pkg/nested/test_thing.py")
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// A bogus rootdir-relative path that exists neither relative to cwd nor as
+    /// a `./<filename>` fallback must surface an error rather than silently
+    /// resolving to the wrong directory (the pre-fix crash path), when no
+    /// absolute test file is provided.
+    #[test]
+    fn test_resolve_without_test_file_errors_on_missing_path() {
+        let info: PytestInfo =
+            "does/not/exist/anywhere/test_missing.py::test_a".parse().unwrap();
+        let result = SnapshotInfo::from_pytest_info(info, None);
+        assert!(
+            result.is_err(),
+            "expected an error when the node-id path cannot be resolved from cwd"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,11 +332,12 @@ pub fn print_pending_diff(pending_path: PathBuf, workspace_root: Option<PathBuf>
 #[pymethods]
 impl SnapshotInfo {
     #[staticmethod]
-    #[pyo3(signature = (snapshot_path_override = None, snapshot_name_override = None, allow_duplicates = false))]
+    #[pyo3(signature = (snapshot_path_override = None, snapshot_name_override = None, allow_duplicates = false, test_file_override = None))]
     fn from_pytest(
         snapshot_path_override: Option<PathBuf>,
         snapshot_name_override: Option<String>,
         allow_duplicates: bool,
+        test_file_override: Option<PathBuf>,
     ) -> PyResult<Self> {
         Ok(
             if let (Some(snapshot_folder), Some(snapshot_name)) = (
@@ -350,7 +351,8 @@ impl SnapshotInfo {
                     allow_duplicates,
                 }
             } else {
-                let pytest_info: SnapshotInfo = PytestInfo::from_env()?.try_into()?;
+                let pytest_info =
+                    SnapshotInfo::from_pytest_info(PytestInfo::from_env()?, test_file_override)?;
                 Self {
                     snapshot_folder: snapshot_path_override.unwrap_or(pytest_info.snapshot_folder),
                     snapshot_name: snapshot_name_override.map_or(pytest_info.snapshot_name, |v| {

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,0 +1,185 @@
+"""Snapshot path resolution must be independent of the process working directory.
+
+``PYTEST_CURRENT_TEST``'s path component is relative to pytest's *rootdir*, not
+to the process CWD. The old Rust layer probed it against ``current_dir()``, so
+snapshots only resolved when pytest ran from its rootdir (or, by luck, the test
+file's own parent); any other CWD raised ``FileNotFoundError`` and recorded zero
+references, silently breaking ``pysnaptest unused`` (which runs with ``cwd=root``).
+
+These tests run pytest from several CWDs and assert snapshots resolve, record
+references, and get created next to the test file regardless.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from pysnaptest._pysnaptest import SNAPSHOT_SUFFIX
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_ROOT = REPO_ROOT / "examples" / "my_project"
+EXAMPLE_TEST = EXAMPLE_ROOT / "tests" / "test_main.py"
+EXAMPLE_SNAPSHOTS = EXAMPLE_ROOT / "tests" / "snapshots"
+
+# test_main -> 1 json snapshot; test_use_http_request -> json + mock request/response.
+EXPECTED_REFERENCES = 4
+CWDS = ["rootdir", "test_parent", "intermediate", "unrelated"]
+
+pytestmark = pytest.mark.skipif(
+    not EXAMPLE_TEST.exists(), reason="bundled example project is not available"
+)
+
+
+def _run_pytest(
+    cwd: Path,
+    root: Path,
+    test_file: Path,
+    *extra: str,
+    extra_env: Optional[dict] = None,
+) -> subprocess.CompletedProcess:
+    """Run pytest against ``test_file`` with rootdir pinned to ``root``.
+
+    Pinning ``--rootdir`` keeps ``PYTEST_CURRENT_TEST`` rootdir-relative (the
+    condition that used to break CWD probing); the absolute test path lets pytest
+    collect the file from any ``cwd``. ``-o env=`` blanks the example's optional
+    pytest-env config so the suite runs without that plugin.
+    """
+
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("INSTA_UPDATE", "PYSNAPTEST_TEST_FILE")
+    }
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(root), env.get("PYTHONPATH", "")])
+    )
+    env.update(extra_env or {})
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "env=",
+            "--rootdir",
+            str(root),
+            str(test_file),
+            "-q",
+            *extra,
+        ],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _referenced(ref_file: Path) -> set:
+    if not ref_file.exists():
+        return set()
+    return {
+        Path(line).resolve()
+        for line in ref_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+
+
+def _example_cwd(kind: str, tmp_path: Path) -> Path:
+    return {
+        "rootdir": EXAMPLE_ROOT,  # always worked
+        "test_parent": EXAMPLE_TEST.parent,  # worked only by accident (./<file> fallback)
+        "intermediate": REPO_ROOT,  # between rootdir and test file: used to fail
+        "unrelated": tmp_path,  # worst case
+    }[kind]
+
+
+@pytest.mark.parametrize("cwd_kind", CWDS)
+def test_snapshots_resolve_regardless_of_cwd(cwd_kind: str, tmp_path: Path) -> None:
+    ref_file = tmp_path / "referenced.txt"
+    result = _run_pytest(
+        _example_cwd(cwd_kind, tmp_path),
+        EXAMPLE_ROOT,
+        EXAMPLE_TEST,
+        extra_env={"INSTA_SNAPSHOT_REFERENCES_FILE": str(ref_file)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    referenced = _referenced(ref_file)
+    assert len(referenced) == EXPECTED_REFERENCES, referenced
+    # Every reference lands in the example's real snapshots dir, proving the
+    # folder came from the test file and not from the cwd.
+    assert {r.parent for r in referenced} == {EXAMPLE_SNAPSHOTS.resolve()}
+
+
+def test_reference_set_is_identical_across_cwds(tmp_path: Path) -> None:
+    sets = {}
+    for kind in CWDS:
+        ref_file = tmp_path / f"{kind}.txt"
+        result = _run_pytest(
+            _example_cwd(kind, tmp_path),
+            EXAMPLE_ROOT,
+            EXAMPLE_TEST,
+            extra_env={"INSTA_SNAPSHOT_REFERENCES_FILE": str(ref_file)},
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        sets[kind] = frozenset(_referenced(ref_file))
+
+    assert len(set(sets.values())) == 1, sets
+
+
+def _scaffold_project(root: Path) -> Path:
+    """Create ``root/pytest.ini`` + ``root/pkg/nested/test_created_here.py``.
+
+    The nesting reproduces the bug: ``root/pkg`` is neither the rootdir nor the
+    test file's own parent.
+    """
+
+    (root / "pytest.ini").write_text("[pytest]\n", encoding="utf-8")
+    test_dir = root / "pkg" / "nested"
+    test_dir.mkdir(parents=True)
+    test_file = test_dir / "test_created_here.py"
+    test_file.write_text(
+        "from pysnaptest import assert_json_snapshot\n\n"
+        "def test_creates_snapshot():\n"
+        "    assert_json_snapshot({'hello': 'world', 'n': 1})\n",
+        encoding="utf-8",
+    )
+    return test_file
+
+
+@pytest.mark.parametrize("cwd_kind", ["rootdir", "intermediate", "unrelated"])
+def test_new_snapshot_is_created_next_to_test_file(
+    cwd_kind: str, tmp_path: Path
+) -> None:
+    """A new snapshot must be written into ``<test_dir>/snapshots`` like insta,
+    whatever directory pytest was launched from."""
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    test_file = _scaffold_project(project)
+    snap_dir = test_file.parent / "snapshots"
+
+    cwd = {
+        "rootdir": project,
+        "intermediate": project / "pkg",
+        "unrelated": tmp_path / "elsewhere",
+    }[cwd_kind]
+    cwd.mkdir(parents=True, exist_ok=True)
+
+    result = _run_pytest(cwd, project, test_file, "--snapshot-update")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    created = list(snap_dir.glob(f"*{SNAPSHOT_SUFFIX}"))
+    assert created, f"no snapshot created in {snap_dir}\n{result.stdout}"
+    assert all(s.parent == snap_dir for s in created)
+    assert any("test_created_here_test_creates_snapshot" in s.name for s in created)
+    # Never created relative to the (differing) cwd.
+    assert not (cwd / "snapshots").exists()

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -6,8 +6,9 @@ snapshots only resolved when pytest ran from its rootdir (or, by luck, the test
 file's own parent); any other CWD raised ``FileNotFoundError`` and recorded zero
 references, silently breaking ``pysnaptest unused`` (which runs with ``cwd=root``).
 
-These tests run pytest from several CWDs and assert snapshots resolve, record
-references, and get created next to the test file regardless.
+These tests scaffold a self-contained project (no third-party deps) and run
+pytest from several CWDs, asserting snapshots resolve, record references, and get
+created next to the test file regardless of where pytest was launched.
 """
 
 from __future__ import annotations
@@ -16,24 +17,15 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import pytest
 
 from pysnaptest._pysnaptest import SNAPSHOT_SUFFIX
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-EXAMPLE_ROOT = REPO_ROOT / "examples" / "my_project"
-EXAMPLE_TEST = EXAMPLE_ROOT / "tests" / "test_main.py"
-EXAMPLE_SNAPSHOTS = EXAMPLE_ROOT / "tests" / "snapshots"
-
-# test_main -> 1 json snapshot; test_use_http_request -> json + mock request/response.
-EXPECTED_REFERENCES = 4
+# The scaffolded test module makes two json-snapshot assertions -> two references.
+EXPECTED_REFERENCES = 2
 CWDS = ["rootdir", "test_parent", "intermediate", "unrelated"]
-
-pytestmark = pytest.mark.skipif(
-    not EXAMPLE_TEST.exists(), reason="bundled example project is not available"
-)
 
 
 def _run_pytest(
@@ -47,8 +39,7 @@ def _run_pytest(
 
     Pinning ``--rootdir`` keeps ``PYTEST_CURRENT_TEST`` rootdir-relative (the
     condition that used to break CWD probing); the absolute test path lets pytest
-    collect the file from any ``cwd``. ``-o env=`` blanks the example's optional
-    pytest-env config so the suite runs without that plugin.
+    collect the file from any ``cwd``.
     """
 
     env = {
@@ -56,9 +47,6 @@ def _run_pytest(
         for k, v in os.environ.items()
         if k not in ("INSTA_UPDATE", "PYSNAPTEST_TEST_FILE")
     }
-    env["PYTHONPATH"] = os.pathsep.join(
-        filter(None, [str(root), env.get("PYTHONPATH", "")])
-    )
     env.update(extra_env or {})
     return subprocess.run(
         [
@@ -67,8 +55,6 @@ def _run_pytest(
             "pytest",
             "-p",
             "no:cacheprovider",
-            "-o",
-            "env=",
             "--rootdir",
             str(root),
             str(test_file),
@@ -92,54 +78,11 @@ def _referenced(ref_file: Path) -> set:
     }
 
 
-def _example_cwd(kind: str, tmp_path: Path) -> Path:
-    return {
-        "rootdir": EXAMPLE_ROOT,  # always worked
-        "test_parent": EXAMPLE_TEST.parent,  # worked only by accident (./<file> fallback)
-        "intermediate": REPO_ROOT,  # between rootdir and test file: used to fail
-        "unrelated": tmp_path,  # worst case
-    }[kind]
-
-
-@pytest.mark.parametrize("cwd_kind", CWDS)
-def test_snapshots_resolve_regardless_of_cwd(cwd_kind: str, tmp_path: Path) -> None:
-    ref_file = tmp_path / "referenced.txt"
-    result = _run_pytest(
-        _example_cwd(cwd_kind, tmp_path),
-        EXAMPLE_ROOT,
-        EXAMPLE_TEST,
-        extra_env={"INSTA_SNAPSHOT_REFERENCES_FILE": str(ref_file)},
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
-
-    referenced = _referenced(ref_file)
-    assert len(referenced) == EXPECTED_REFERENCES, referenced
-    # Every reference lands in the example's real snapshots dir, proving the
-    # folder came from the test file and not from the cwd.
-    assert {r.parent for r in referenced} == {EXAMPLE_SNAPSHOTS.resolve()}
-
-
-def test_reference_set_is_identical_across_cwds(tmp_path: Path) -> None:
-    sets = {}
-    for kind in CWDS:
-        ref_file = tmp_path / f"{kind}.txt"
-        result = _run_pytest(
-            _example_cwd(kind, tmp_path),
-            EXAMPLE_ROOT,
-            EXAMPLE_TEST,
-            extra_env={"INSTA_SNAPSHOT_REFERENCES_FILE": str(ref_file)},
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
-        sets[kind] = frozenset(_referenced(ref_file))
-
-    assert len(set(sets.values())) == 1, sets
-
-
 def _scaffold_project(root: Path) -> Path:
     """Create ``root/pytest.ini`` + ``root/pkg/nested/test_created_here.py``.
 
-    The nesting reproduces the bug: ``root/pkg`` is neither the rootdir nor the
-    test file's own parent.
+    The nesting is what reproduces the bug: ``root/pkg`` is neither the rootdir
+    nor the test file's own parent.
     """
 
     (root / "pytest.ini").write_text("[pytest]\n", encoding="utf-8")
@@ -148,11 +91,77 @@ def _scaffold_project(root: Path) -> Path:
     test_file = test_dir / "test_created_here.py"
     test_file.write_text(
         "from pysnaptest import assert_json_snapshot\n\n"
-        "def test_creates_snapshot():\n"
-        "    assert_json_snapshot({'hello': 'world', 'n': 1})\n",
+        "def test_alpha():\n"
+        "    assert_json_snapshot({'hello': 'world', 'n': 1})\n\n"
+        "def test_beta():\n"
+        "    assert_json_snapshot(['a', 'b', 'c'])\n",
         encoding="utf-8",
     )
     return test_file
+
+
+def _cwd(kind: str, project: Path, test_file: Path, tmp_path: Path) -> Path:
+    cwd = {
+        "rootdir": project,  # always worked
+        "test_parent": test_file.parent,  # worked only by accident (./<file> fallback)
+        "intermediate": project / "pkg",  # between rootdir and test file: used to fail
+        "unrelated": tmp_path / "elsewhere",  # worst case
+    }[kind]
+    cwd.mkdir(parents=True, exist_ok=True)
+    return cwd
+
+
+@pytest.fixture
+def committed_project(tmp_path: Path) -> Tuple[Path, Path, Path]:
+    """Scaffold a project and create its committed snapshots from the rootdir."""
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    test_file = _scaffold_project(project)
+    result = _run_pytest(project, project, test_file, "--snapshot-update")
+    assert result.returncode == 0, result.stdout + result.stderr
+    return project, test_file, test_file.parent / "snapshots"
+
+
+@pytest.mark.parametrize("cwd_kind", CWDS)
+def test_snapshots_resolve_regardless_of_cwd(
+    cwd_kind: str, committed_project: Tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    project, test_file, snap_dir = committed_project
+    ref_file = tmp_path / "referenced.txt"
+
+    result = _run_pytest(
+        _cwd(cwd_kind, project, test_file, tmp_path),
+        project,
+        test_file,
+        extra_env={"INSTA_SNAPSHOT_REFERENCES_FILE": str(ref_file)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    referenced = _referenced(ref_file)
+    assert len(referenced) == EXPECTED_REFERENCES, referenced
+    # Every reference lands in the test file's own snapshots dir, proving the
+    # folder came from the test file and not from the cwd.
+    assert {r.parent for r in referenced} == {snap_dir.resolve()}
+
+
+def test_reference_set_is_identical_across_cwds(
+    committed_project: Tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    project, test_file, _ = committed_project
+    sets = {}
+    for kind in CWDS:
+        ref_file = tmp_path / f"{kind}.txt"
+        result = _run_pytest(
+            _cwd(kind, project, test_file, tmp_path),
+            project,
+            test_file,
+            extra_env={"INSTA_SNAPSHOT_REFERENCES_FILE": str(ref_file)},
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        sets[kind] = frozenset(_referenced(ref_file))
+
+    assert len(set(sets.values())) == 1, sets
 
 
 @pytest.mark.parametrize("cwd_kind", ["rootdir", "intermediate", "unrelated"])
@@ -166,13 +175,7 @@ def test_new_snapshot_is_created_next_to_test_file(
     project.mkdir()
     test_file = _scaffold_project(project)
     snap_dir = test_file.parent / "snapshots"
-
-    cwd = {
-        "rootdir": project,
-        "intermediate": project / "pkg",
-        "unrelated": tmp_path / "elsewhere",
-    }[cwd_kind]
-    cwd.mkdir(parents=True, exist_ok=True)
+    cwd = _cwd(cwd_kind, project, test_file, tmp_path)
 
     result = _run_pytest(cwd, project, test_file, "--snapshot-update")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -180,6 +183,6 @@ def test_new_snapshot_is_created_next_to_test_file(
     created = list(snap_dir.glob(f"*{SNAPSHOT_SUFFIX}"))
     assert created, f"no snapshot created in {snap_dir}\n{result.stdout}"
     assert all(s.parent == snap_dir for s in created)
-    assert any("test_created_here_test_creates_snapshot" in s.name for s in created)
+    assert any("test_created_here_test_alpha" in s.name for s in created)
     # Never created relative to the (differing) cwd.
     assert not (cwd / "snapshots").exists()


### PR DESCRIPTION
PytestInfo::test_path() resolved the PYTEST_CURRENT_TEST path (which is always relative to pytest's rootdir) against the process working directory. When pytest ran from any directory other than its rootdir (or, by accident, the test file's own parent), every snapshot assertion raised FileNotFoundError and recorded zero references, silently under-recording INSTA_SNAPSHOT_REFERENCES_FILE and breaking downstream tools like 'pysnaptest unused'.

The pytest plugin now exports the test's absolute path (item.path, always absolute) via PYSNAPTEST_TEST_FILE; the Rust layer resolves the snapshots/ folder from that file while still deriving the snapshot name and the stored Test File Path description from the rootdir-relative node id, so committed snapshots are unchanged. Falls back to the legacy CWD probing when absent.

Adds Rust unit tests and a Python integration suite that runs the example project and a scaffolded project from rootdir/intermediate/unrelated CWDs, asserting references are recorded and new snapshots are created next to the test file regardless of invocation directory.