### PR TITLE
Fix panic in pysnaptest review/pending with relative --root

### DIFF
--- a/python/pysnaptest/review.py
+++ b/python/pysnaptest/review.py
@@ -83,7 +83,9 @@ def print_pending_diff(pending_path: str | Path, root: Optional[str] = None) -> 
             ``INSTA_WORKSPACE_ROOT`` if set, otherwise the current directory.
     """
 
-    _print_pending_diff(str(pending_path), str(_root(root)))
+    # insta's diff printer requires an absolute workspace root; the default of
+    # ``.`` (or any relative ``--root``) would otherwise panic in the Rust layer.
+    _print_pending_diff(str(pending_path), str(_root(root).resolve()))
 
 
 def accept_all(root: Optional[str] = None) -> List[Path]:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,16 @@ pub fn print_pending_diff(pending_path: PathBuf, workspace_root: Option<PathBuf>
         .or_else(|| std::env::var_os("INSTA_WORKSPACE_ROOT").map(PathBuf::from))
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| PathBuf::from("."));
+    // insta's `SnapshotPrinter` asserts the workspace root is absolute, so a
+    // relative root (e.g. the CLI's default of ".") would otherwise panic. Anchor
+    // any relative root against the current directory before handing it off.
+    let root = if root.is_absolute() {
+        root
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&root))
+            .unwrap_or(root)
+    };
     let title = new_snapshot
         .snapshot_name()
         .unwrap_or("snapshot")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -132,3 +132,38 @@ def test_snapshot_update_flag_updates_in_place(tmp_path: Path) -> None:
     assert find_pending_snapshots(str(tmp_path)) == []
     committed = next((tmp_path / "snapshots").glob("*@pysnap.snap"))
     assert "VERSION_B" in committed.read_text()
+
+
+def test_print_pending_diff_relative_root_does_not_panic(tmp_path: Path, capfd) -> None:
+    # A relative workspace root (e.g. the CLI's default of ".") must not reach
+    # insta's `assert!(path.is_absolute())` in the Rust diff printer.
+    accept_pending_snapshot(_make_pending(tmp_path, "VERSION_A"))
+    _write_project(tmp_path, "VERSION_B")
+    _run_pytest(tmp_path, "--snapshot-new")
+    pending = find_pending_snapshots(str(tmp_path))[0]
+
+    print_pending_diff(pending, ".")
+
+    assert "VERSION_B" in capfd.readouterr().out
+
+
+def test_cli_pending_without_root_from_cwd(tmp_path: Path) -> None:
+    # `pysnaptest pending` with no --root defaults root to "." and previously
+    # panicked in the Rust layer; run from the project cwd with a clean env
+    # (no INSTA_WORKSPACE_ROOT) to reproduce that exact invocation.
+    accept_pending_snapshot(_make_pending(tmp_path, "VERSION_A"))
+    _write_project(tmp_path, "VERSION_B")
+    _run_pytest(tmp_path, "--snapshot-new")
+
+    env = {k: v for k, v in os.environ.items() if k != "INSTA_WORKSPACE_ROOT"}
+    result = subprocess.run(
+        [sys.executable, "-m", "pysnaptest", "pending"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "VERSION_B" in result.stdout
+    assert "1 pending snapshot(s)." in result.stdout


### PR DESCRIPTION
## Problem

`pysnaptest review` (and `pysnaptest pending`) panic when run without an absolute `--root`. The CLI defaults `--root` to the relative `"."` when neither `--root` nor `INSTA_WORKSPACE_ROOT` is set, and that relative path is passed straight through to the Rust `print_pending_diff`. insta's `SnapshotPrinter` asserts the workspace root is absolute (`assert!(path.is_absolute())`), so the relative root panics in the Rust layer on every OS.

The only workaround was to pass an absolute `--root` **before** the subcommand (e.g. `pysnaptest --root $PWD review`).

## Fix (defense in depth)

- **Rust** (`src/lib.rs`): `print_pending_diff` now anchors any relative resolved root against the current directory before constructing `SnapshotPrinter`, protecting every caller of the compiled API.
- **Python** (`review.py`): `print_pending_diff` resolves the root to an absolute path before the FFI call, so the CLI works immediately without a rebuild.

## Tests

Added regression tests in `tests/test_review.py`:
- `test_print_pending_diff_relative_root_does_not_panic` — calls `print_pending_diff(pending, ".")`.
- `test_cli_pending_without_root_from_cwd` — runs the `pysnaptest pending` CLI with no `--root` and `INSTA_WORKSPACE_ROOT` stripped from the env.

Full suite passes (`94 passed, 2 skipped`); `cargo fmt --check`, `clippy`, and `ruff format --check` are clean.
